### PR TITLE
:children_crossing: make package `netstandard2.0` compatible

### DIFF
--- a/QsNet.Tests/UtilsTests.cs
+++ b/QsNet.Tests/UtilsTests.cs
@@ -1355,36 +1355,6 @@ public class UtilsTests
     }
 
     [Fact]
-    public void ToStringKeyedDictionary_Converts_Keys_To_String()
-    {
-        var src = new OrderedDictionary
-        {
-            { "a", 1 }, // string key
-            { 2, "b" }, // int   key
-            { "", 3 } // null  key
-        };
-
-        var dict =
-            (Dictionary<string, object?>)
-            typeof(Utils)
-                .GetMethod(
-                    "ToStringKeyedDictionary",
-                    BindingFlags.NonPublic | BindingFlags.Static
-                )!
-                .Invoke(null, [src])!;
-
-        dict.Should()
-            .BeEquivalentTo(
-                new Dictionary<string, object?>
-                {
-                    ["a"] = 1,
-                    ["2"] = "b", // int key → "2"
-                    [""] = 3 // null key → ""
-                }
-            );
-    }
-
-    [Fact]
     public void ConvertDictionaryToStringKeyed_Does_Not_Copy_If_Already_StringKeyed()
     {
         var src = new Dictionary<string, object?> { ["a"] = 7 };

--- a/QsNet/Compat/IsExternalInit.cs
+++ b/QsNet/Compat/IsExternalInit.cs
@@ -1,0 +1,11 @@
+#if NETSTANDARD2_0
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    ///     Polyfill for init-only setters on netstandard2.0.
+    /// </summary>
+    internal static class IsExternalInit
+    {
+    }
+}
+#endif

--- a/QsNet/Enums/ListFormat.cs
+++ b/QsNet/Enums/ListFormat.cs
@@ -41,6 +41,11 @@ public enum ListFormat
 /// </summary>
 public static class ListFormatExtensions
 {
+    private static readonly ListFormatGenerator BracketsGen = (p, _) => $"{p}[]";
+    private static readonly ListFormatGenerator CommaGen = (p, _) => p;
+    private static readonly ListFormatGenerator RepeatGen = (p, _) => p;
+    private static readonly ListFormatGenerator IndicesGen = (p, k) => $"{p}[{k}]";
+
     /// <summary>
     ///     Gets the generator function for the specified list format.
     /// </summary>
@@ -50,10 +55,10 @@ public static class ListFormatExtensions
     {
         return format switch
         {
-            ListFormat.Brackets => (prefix, _) => $"{prefix}[]",
-            ListFormat.Comma => (prefix, _) => prefix,
-            ListFormat.Repeat => (prefix, _) => prefix,
-            ListFormat.Indices => (prefix, key) => $"{prefix}[{key}]",
+            ListFormat.Brackets => BracketsGen,
+            ListFormat.Comma => CommaGen,
+            ListFormat.Repeat => RepeatGen,
+            ListFormat.Indices => IndicesGen,
             _ => throw new ArgumentOutOfRangeException(nameof(format))
         };
     }

--- a/QsNet/Internal/Utils.cs
+++ b/QsNet/Internal/Utils.cs
@@ -1049,7 +1049,6 @@ internal static partial class Utils
                             visited[list] = newList;
 
                             foreach (var item in list)
-                            {
                                 if (item is IDictionary inner)
                                 {
                                     if (inner is Dictionary<string, object?> innerSk)
@@ -1073,7 +1072,6 @@ internal static partial class Utils
                                 {
                                     newList.Add(item);
                                 }
-                            }
 
                             break;
 

--- a/QsNet/Internal/Utils.cs
+++ b/QsNet/Internal/Utils.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
@@ -15,7 +16,11 @@ namespace QsNet.Internal;
 /// <summary>
 ///     A collection of utility methods used by the library.
 /// </summary>
+#if NETSTANDARD2_0
+internal static class Utils
+#else
 internal static partial class Utils
+#endif
 {
     /// <summary>
     ///     The maximum length of a segment to encode in a single pass.
@@ -25,14 +30,32 @@ internal static partial class Utils
     /// <summary>
     ///     A regex to match percent-encoded characters in the format %XX.
     /// </summary>
+#if NETSTANDARD2_0
+    private static readonly Regex MyRegexInstance = new("%[0-9a-f]{2}", RegexOptions.IgnoreCase);
+
+    private static Regex MyRegex()
+    {
+        return MyRegexInstance;
+    }
+#else
     [GeneratedRegex("%[0-9a-f]{2}", RegexOptions.IgnoreCase, "en-GB")]
     private static partial Regex MyRegex();
+#endif
 
     /// <summary>
     ///     A regex to match Unicode percent-encoded characters in the format %uXXXX.
     /// </summary>
+#if NETSTANDARD2_0
+    private static readonly Regex MyRegex1Instance = new("%u[0-9a-f]{4}", RegexOptions.IgnoreCase);
+
+    private static Regex MyRegex1()
+    {
+        return MyRegex1Instance;
+    }
+#else
     [GeneratedRegex("%u[0-9a-f]{4}", RegexOptions.IgnoreCase, "en-GB")]
     private static partial Regex MyRegex1();
+#endif
 
     /// <summary>
     ///     Merges two objects, where the source object overrides the target object. If the source is a
@@ -93,9 +116,12 @@ internal static partial class Utils
                         // Otherwise: both sides are iterables / primitives
                         if (source is IEnumerable<object?> srcIt)
                         {
+                            // Materialize once to avoid multiple enumeration of a potentially lazy sequence
+                            var srcList = srcIt as IList<object?> ?? srcIt.ToList();
+
                             // If both sequences are maps-or-Undefined only, fold by index merging
                             var targetAllMaps = targetList.All(v => v is IDictionary or Undefined);
-                            var srcAllMaps = srcIt.All(v => v is IDictionary or Undefined);
+                            var srcAllMaps = srcList.All(v => v is IDictionary or Undefined);
 
                             if (targetAllMaps && srcAllMaps)
                             {
@@ -104,10 +130,12 @@ internal static partial class Utils
                                     mutable[i] = targetList[i];
 
                                 var j = 0;
-                                foreach (var item in srcIt)
+                                foreach (var item in srcList)
                                 {
-                                    if (!mutable.TryAdd(j, item))
+                                    if (mutable.ContainsKey(j))
                                         mutable[j] = Merge(mutable[j], item, options);
+                                    else
+                                        mutable.Add(j, item);
 
                                     j++;
                                 }
@@ -118,7 +146,7 @@ internal static partial class Utils
                             }
 
                             // Fallback: concat, filtering out Undefined from source
-                            var filtered = srcIt.Where(v => v is not Undefined);
+                            var filtered = srcList.Where(v => v is not Undefined);
                             if (target is ISet<object?>)
                                 return new HashSet<object?>(targetList.Concat(filtered));
                             return targetList.Concat(filtered).ToList();
@@ -274,15 +302,27 @@ internal static partial class Utils
             {
                 if (i + 1 < str.Length && str[i + 1] == 'u')
                 {
+#if NETSTANDARD2_0
                     if (
-                        i + 6 <= str.Length
-                        && int.TryParse(
+                        i + 6 <= str.Length &&
+                        int.TryParse(
+                            str.Substring(i + 2, 4),
+                            NumberStyles.HexNumber,
+                            null,
+                            out var code
+                        )
+                    )
+#else
+                    if (
+                        i + 6 <= str.Length &&
+                        int.TryParse(
                             str.AsSpan(i + 2, 4),
                             NumberStyles.HexNumber,
                             null,
                             out var code
                         )
                     )
+#endif
                     {
                         sb.Append((char)code);
                         i += 6;
@@ -291,7 +331,11 @@ internal static partial class Utils
                 }
                 else if (
                     i + 3 <= str.Length
+#if NETSTANDARD2_0
+                    && int.TryParse(str.Substring(i + 1, 2), NumberStyles.HexNumber, null, out var b)
+#else
                     && int.TryParse(str.AsSpan(i + 1, 2), NumberStyles.HexNumber, null, out var b)
+#endif
                 )
                 {
                     sb.Append((char)b);
@@ -318,6 +362,7 @@ internal static partial class Utils
     {
         encoding ??= Encoding.UTF8;
         format ??= Format.Rfc3986;
+        var fmt = format.GetValueOrDefault();
 
         // These cannot be encoded
         if (value is IEnumerable and not string and not byte[] or IDictionary or Undefined)
@@ -332,16 +377,21 @@ internal static partial class Utils
 
         if (string.IsNullOrEmpty(str))
             return string.Empty;
+        var nonNullStr = str!;
 
         if (Equals(encoding, Encoding.GetEncoding("ISO-8859-1")))
         {
 #pragma warning disable CS0618 // Type or member is obsolete
             return MyRegex1()
                 .Replace(
-                    Escape(str, format.Value),
+                    Escape(str!, fmt),
                     match =>
                     {
+#if NETSTANDARD2_0
+                        var code = int.Parse(match.Value.Substring(2), NumberStyles.HexNumber);
+#else
                         var code = int.Parse(match.Value[2..], NumberStyles.HexNumber);
+#endif
                         return $"%26%23{code}%3B";
                     }
                 );
@@ -351,12 +401,12 @@ internal static partial class Utils
         var buffer = new StringBuilder();
         var j = 0;
 
-        while (j < str.Length)
+        while (j < nonNullStr.Length)
         {
             var segment =
-                str.Length >= SegmentLimit
-                    ? str.Substring(j, Math.Min(SegmentLimit, str.Length - j))
-                    : str;
+                nonNullStr.Length >= SegmentLimit
+                    ? nonNullStr.Substring(j, Math.Min(SegmentLimit, nonNullStr.Length - j))
+                    : nonNullStr;
 
             var i = 0;
             while (i < segment.Length)
@@ -369,7 +419,7 @@ internal static partial class Utils
                     case >= 0x30 and <= 0x39:
                     case >= 0x41 and <= 0x5A:
                     case >= 0x61 and <= 0x7A:
-                    case 0x28 or 0x29 when format == Format.Rfc1738:
+                    case 0x28 or 0x29 when fmt == Format.Rfc1738:
                         buffer.Append(segment[i]);
                         i++;
                         continue;
@@ -775,22 +825,6 @@ internal static partial class Utils
     }
 
     /// <summary>
-    ///     string-keyed view
-    /// </summary>
-    /// <param name="src"></param>
-    /// <returns></returns>
-    private static Dictionary<string, object?> ToStringKeyedDictionary(IDictionary src)
-    {
-        if (src is Dictionary<string, object?> strDict)
-            return strDict;
-
-        var dict = new Dictionary<string, object?>(src.Count);
-        foreach (DictionaryEntry de in src)
-            dict[de.Key.ToString() ?? string.Empty] = de.Value;
-        return dict;
-    }
-
-    /// <summary>
     ///     Helper to convert an IDictionary to Dictionary&lt;string, object?&gt;.
     /// </summary>
     /// <param name="dictionary">The dictionary to convert</param>
@@ -876,7 +910,7 @@ internal static partial class Utils
             // Fallback: make a shallow string-keyed view without descending
             var shallow = new Dictionary<string, object?>(dict.Count);
             foreach (DictionaryEntry de in dict)
-                shallow[de.Key?.ToString() ?? string.Empty] = de.Value;
+                shallow[de.Key.ToString() ?? string.Empty] = de.Value;
             return shallow;
         }
 
@@ -884,7 +918,7 @@ internal static partial class Utils
 
         foreach (DictionaryEntry entry in dict)
         {
-            var key = entry.Key?.ToString() ?? string.Empty;
+            var key = entry.Key.ToString() ?? string.Empty;
             var item = entry.Value;
 
             switch (item)
@@ -974,7 +1008,7 @@ internal static partial class Utils
             if (src is IDictionary sd && dst is Dictionary<string, object?> dd)
                 foreach (DictionaryEntry de in sd)
                 {
-                    var key = de.Key?.ToString() ?? string.Empty;
+                    var key = de.Key.ToString() ?? string.Empty;
                     var val = de.Value;
 
                     switch (val)
@@ -1014,9 +1048,8 @@ internal static partial class Utils
                             dd[key] = newList;
                             visited[list] = newList;
 
-                            for (var i = 0; i < list.Count; i++)
+                            foreach (var item in list)
                             {
-                                var item = list[i];
                                 if (item is IDictionary inner)
                                 {
                                     if (inner is Dictionary<string, object?> innerSk)
@@ -1052,5 +1085,25 @@ internal static partial class Utils
         }
 
         return top;
+    }
+}
+
+// Reference-equality comparer used to track visited nodes without relying on value equality
+internal sealed class ReferenceEqualityComparer : IEqualityComparer<object>
+{
+    public static readonly ReferenceEqualityComparer Instance = new();
+
+    private ReferenceEqualityComparer()
+    {
+    }
+
+    public new bool Equals(object? x, object? y)
+    {
+        return ReferenceEquals(x, y);
+    }
+
+    public int GetHashCode(object obj)
+    {
+        return RuntimeHelpers.GetHashCode(obj);
     }
 }

--- a/QsNet/Models/DecodeOptions.cs
+++ b/QsNet/Models/DecodeOptions.cs
@@ -28,8 +28,14 @@ public sealed class DecodeOptions
     /// </summary>
     public DecodeOptions()
     {
-        // Validation
-        if (!Equals(Charset, Encoding.UTF8) && !Equals(Charset, Encoding.Latin1))
+        if (
+            !Equals(Charset, Encoding.UTF8) &&
+#if NETSTANDARD2_0
+            Charset.CodePage != 28591
+#else
+            !Equals(Charset, Encoding.Latin1)
+#endif
+        )
             throw new ArgumentException("Invalid charset");
 
         if (ParameterLimit <= 0)

--- a/QsNet/Models/Delimiter.cs
+++ b/QsNet/Models/Delimiter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
@@ -30,7 +31,11 @@ public sealed record StringDelimiter(string Value) : IDelimiter
     /// <returns>A list of split strings</returns>
     public IEnumerable<string> Split(string input)
     {
+#if NETSTANDARD2_0
+        return Value.Length == 1 ? input.Split(Value[0]) : input.Split([Value], StringSplitOptions.None);
+#else
         return input.Split(Value);
+#endif
     }
 }
 

--- a/QsNet/Models/EncodeOptions.cs
+++ b/QsNet/Models/EncodeOptions.cs
@@ -43,8 +43,14 @@ public sealed class EncodeOptions
     {
         ListFormat = listFormat;
 
-        // Validate charset
-        if (!Equals(Charset, Encoding.UTF8) && !Equals(Charset, Encoding.Latin1))
+        if (
+            !Equals(Charset, Encoding.UTF8) &&
+#if NETSTANDARD2_0
+            Charset.CodePage != 28591
+#else
+            !Equals(Charset, Encoding.Latin1)
+#endif
+        )
             throw new ArgumentException("Invalid charset");
     }
 

--- a/QsNet/QsNet.csproj
+++ b/QsNet/QsNet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This pull request introduces comprehensive compatibility improvements for `netstandard2.0`, refactors utility and decoder logic for better maintainability, and optimizes handling of collections and string operations. The most important changes are grouped below.

### .NET Standard 2.0 Compatibility

* Added a polyfill for `IsExternalInit` in `QsNet/Compat/IsExternalInit.cs` to support init-only setters on `netstandard2.0`.
* Refactored `Decoder` and `Utils` classes to use conditional compilation (`#if NETSTANDARD2_0`) for regex usage, string slicing, and encoding operations to ensure compatibility with `netstandard2.0`. [[1]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946R15-R50) [[2]](diffhunk://#diff-d6d00580c30cce84e82a906209cc9cdd38f667af22adc290a3fec7d3a3287d8aR19-R23) [[3]](diffhunk://#diff-d6d00580c30cce84e82a906209cc9cdd38f667af22adc290a3fec7d3a3287d8aR33-R58)

### Decoder Logic Enhancements

* Updated key and value parsing in `Decoder.cs` to use compatible string slicing and encoding checks, including a custom case-insensitive string replace for query parameter normalization. [[1]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946R99-R107) [[2]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946R167-R192) [[3]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946R284-R290) [[4]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946R393-R397) [[5]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946R408-R412) [[6]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946L360-R457)
* Improved handling of Latin1 encoding detection and usage, abstracting it via a helper property and function for cross-version compatibility. [[1]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946L109-R141) [[2]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946R167-R192)

### Utility Method Refactoring

* Optimized collection merging in `Utils.cs` by materializing enumerables to lists before processing, preventing multiple enumerations and improving performance. [[1]](diffhunk://#diff-d6d00580c30cce84e82a906209cc9cdd38f667af22adc290a3fec7d3a3287d8aR119-R124) [[2]](diffhunk://#diff-d6d00580c30cce84e82a906209cc9cdd38f667af22adc290a3fec7d3a3287d8aL107-R138) [[3]](diffhunk://#diff-d6d00580c30cce84e82a906209cc9cdd38f667af22adc290a3fec7d3a3287d8aL121-R149)
* Refactored percent-encoding and decoding logic to use compatible string operations for both `netstandard2.0` and newer frameworks, including handling of Unicode and hex escapes. [[1]](diffhunk://#diff-d6d00580c30cce84e82a906209cc9cdd38f667af22adc290a3fec7d3a3287d8aR305-R325) [[2]](diffhunk://#diff-d6d00580c30cce84e82a906209cc9cdd38f667af22adc290a3fec7d3a3287d8aR334-R338) [[3]](diffhunk://#diff-d6d00580c30cce84e82a906209cc9cdd38f667af22adc290a3fec7d3a3287d8aR365) [[4]](diffhunk://#diff-d6d00580c30cce84e82a906209cc9cdd38f667af22adc290a3fec7d3a3287d8aR380-R394) [[5]](diffhunk://#diff-d6d00580c30cce84e82a906209cc9cdd38f667af22adc290a3fec7d3a3287d8aL354-R409)

### ListFormat Extension Improvements

* Refactored `ListFormatExtensions` to use static generator delegates for each format, reducing allocations and improving clarity. [[1]](diffhunk://#diff-5dd1a52a9d428610b686c95890e5eca11301ba696b9dc1f4f6431c546faca590R44-R48) [[2]](diffhunk://#diff-5dd1a52a9d428610b686c95890e5eca11301ba696b9dc1f4f6431c546faca590L53-R61)

### Test Suite Cleanup

* Removed obsolete or redundant test `ToStringKeyedDictionary_Converts_Keys_To_String` from `UtilsTests.cs` to streamline the test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added .NET Standard 2.0 support.
  - Introduced a regex-based delimiter option for splitting input.
- Refactor
  - Improved performance and compatibility in encoding/decoding paths.
  - More robust handling of complex dictionary/list structures and circular references.
  - Minor optimizations in list formatting behavior.
- Tests
  - Updated unit tests, removing a redundant case.
- Chores
  - Switched to multi-target builds (net8.0 and netstandard2.0) for broader platform coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->