### PR TITLE
:construction_worker: expanded CI with multi-target smoke tests (.NET 5–9, 10 preview), Windows .NET Framework smoke, and a compile-only .NET Core 3.1 check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,19 +44,33 @@ jobs:
     name: Test ${{ matrix.dotnet }} on ${{ matrix.os }}
     needs: lint
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        dotnet: 
-          - '8.0.x'
-          - '9.0.x'
+        include:
+          - os: ubuntu-latest
+            dotnet: '8.0.x'
+            experimental: false
+          - os: ubuntu-latest
+            dotnet: '9.0.x'
+            experimental: false
+          - os: ubuntu-latest
+            dotnet: '10.0.x'
+            experimental: true
     steps:
       - uses: actions/checkout@v5
-      - name: Setup .NET SDK
+      - name: Setup .NET SDK (stable)
+        if: ${{ matrix.dotnet != '10.0.x' }}
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet }}
+      - name: Setup .NET SDK (10 preview)
+        if: ${{ matrix.dotnet == '10.0.x' }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-quality: preview
       - name: Cache NuGet
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,6 +268,11 @@ jobs:
         with:
           name: qsnet-nupkg
           path: ./nupkg
+      - name: Verify local nupkg
+        run: |
+          set -eu
+          echo "Listing ${{ github.workspace }}/nupkg";
+          ls -la "${{ github.workspace }}/nupkg" || { echo "nupkg directory missing"; exit 1; }
       - name: Ensure git in container
         run: |
           set -eu
@@ -312,7 +317,7 @@ jobs:
           }
           CS
       - name: Restore consumer
-        run: dotnet restore consumer-core31/consumer-core31.csproj --source ./nupkg --source https://api.nuget.org/v3/index.json
+        run: dotnet restore consumer-core31/consumer-core31.csproj --source "${{ github.workspace }}/nupkg" --source https://api.nuget.org/v3/index.json
       - name: Build consumer (compile only)
         run: dotnet build -c Release consumer-core31/consumer-core31.csproj --no-restore
   smoke_netfx:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,7 +246,7 @@ jobs:
           set -euo pipefail
           dotnet run -c Release --framework net10.0 --project consumer-smoke/consumer-smoke.csproj --no-build
   smoke_netfx:
-    name: Consumer smoke (.NET Framework 4.6.1 on Windows)
+    name: Consumer smoke (.NET Framework 4.6.1 & 4.8.1 on Windows)
     needs: lint
     runs-on: windows-latest
     steps:
@@ -265,7 +265,7 @@ jobs:
           <Project Sdk="Microsoft.NET.Sdk">
             <PropertyGroup>
               <OutputType>Exe</OutputType>
-              <TargetFramework>net461</TargetFramework>
+              <TargetFrameworks>net461;net481</TargetFrameworks>
               <Nullable>enable</Nullable>
               <ImplicitUsings>false</ImplicitUsings>
               <LangVersion>8.0</LangVersion>
@@ -273,6 +273,7 @@ jobs:
             <ItemGroup>
               <ProjectReference Include="../QsNet/QsNet.csproj" />
               <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+              <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
             </ItemGroup>
           </Project>
           XML
@@ -309,6 +310,8 @@ jobs:
         run: dotnet build -c Release consumer-netfx/consumer-netfx.csproj --no-restore
       - name: Run smoke (net461)
         run: dotnet run -c Release --framework net461 --project consumer-netfx/consumer-netfx.csproj --no-build
+      - name: Run smoke (net481)
+        run: dotnet run -c Release --framework net481 --project consumer-netfx/consumer-netfx.csproj --no-build
   coverage:
     name: Coverage (merged)
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,12 +158,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Setup .NET SDKs (5, 6, 8, 9)
+      - name: Setup .NET SDKs (5, 6, 7, 8, 9)
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             5.0.x
             6.0.x
+            7.0.x
             8.0.x
             9.0.x
       - name: Setup .NET 10 preview SDK (non-blocking)
@@ -180,7 +181,7 @@ jobs:
           <Project Sdk="Microsoft.NET.Sdk">
             <PropertyGroup>
               <OutputType>Exe</OutputType>
-              <TargetFrameworks>net5.0;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
+              <TargetFrameworks>net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
               <Nullable>enable</Nullable>
               <ImplicitUsings>false</ImplicitUsings>
             </PropertyGroup>
@@ -220,10 +221,10 @@ jobs:
           CS
       - name: Restore consumer
         run: dotnet restore consumer-smoke/consumer-smoke.csproj
-      - name: Build consumer (net6.0; net8.0; net9.0)
+      - name: Build consumer (net6.0; net7.0; net8.0; net9.0)
         run: |
           set -euo pipefail
-          for f in net6.0 net8.0 net9.0; do
+          for f in net6.0 net7.0 net8.0 net9.0; do
             echo "Building $f"
             dotnet build -c Release -f "$f" consumer-smoke/consumer-smoke.csproj --no-restore
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,6 +245,55 @@ jobs:
         run: |
           set -euo pipefail
           dotnet run -c Release --framework net10.0 --project consumer-smoke/consumer-smoke.csproj --no-build
+  smoke_netcore31:
+    name: Consumer smoke (netcoreapp3.1 compile-only)
+    needs: lint
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup .NET 3.1 SDK (non-blocking)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '3.1.x'
+      - name: Create consumer project (netcoreapp3.1)
+        run: |
+          set -euo pipefail
+          mkdir -p consumer-core31
+          cat > consumer-core31/consumer-core31.csproj <<'XML'
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+              <OutputType>Exe</OutputType>
+              <TargetFramework>netcoreapp3.1</TargetFramework>
+              <Nullable>enable</Nullable>
+              <ImplicitUsings>false</ImplicitUsings>
+            </PropertyGroup>
+            <ItemGroup>
+              <ProjectReference Include="../QsNet/QsNet.csproj" />
+            </ItemGroup>
+          </Project>
+          XML
+          cat > consumer-core31/Program.cs <<'CS'
+          using System;
+          using System.Collections.Generic;
+          using QsNet;
+          class P
+          {
+              static int Main()
+              {
+                  // compile-only smoke; not executed in CI
+                  var decoded = Qs.Decode("a[b]=c&x[]=1&x[]=2");
+                  var qs = Qs.Encode(new Dictionary<string, object?> {
+                      ["a"] = new Dictionary<string, object?> { ["b"] = "c" }
+                  });
+                  return string.IsNullOrEmpty(qs) ? 1 : 0;
+              }
+          }
+          CS
+      - name: Restore consumer
+        run: dotnet restore consumer-core31/consumer-core31.csproj
+      - name: Build consumer (compile only)
+        run: dotnet build -c Release consumer-core31/consumer-core31.csproj --no-restore
   smoke_netfx:
     name: Consumer smoke (.NET Framework 4.6.1 & 4.8.1 on Windows)
     needs: lint
@@ -325,6 +374,7 @@ jobs:
       - test
       - ensure_compatibility
       - smoke
+      - smoke_netcore31
       - smoke_netfx
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,15 +130,16 @@ jobs:
             cs.out
             diff.out
   smoke:
-    name: Consumer smoke (net6.0; net8.0; net9.0)
+    name: Consumer smoke (net5.0; net6.0; net8.0; net9.0)
     needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Setup .NET SDKs (6, 8, 9)
+      - name: Setup .NET SDKs (5, 6, 8, 9)
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            5.0.x
             6.0.x
             8.0.x
             9.0.x
@@ -150,7 +151,7 @@ jobs:
           <Project Sdk="Microsoft.NET.Sdk">
             <PropertyGroup>
               <OutputType>Exe</OutputType>
-              <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+              <TargetFrameworks>net5.0;net6.0;net8.0;net9.0</TargetFrameworks>
               <Nullable>enable</Nullable>
               <ImplicitUsings>enable</ImplicitUsings>
             </PropertyGroup>
@@ -192,6 +193,11 @@ jobs:
         run: dotnet restore consumer-smoke/consumer-smoke.csproj
       - name: Build consumer
         run: dotnet build -c Release consumer-smoke/consumer-smoke.csproj --no-restore
+      - name: Run smoke (net5.0 — non-blocking)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          dotnet run -c Release --framework net5.0 --project consumer-smoke/consumer-smoke.csproj --no-build
       - name: Run smoke (net6.0; net8.0; net9.0)
         run: |
           set -euo pipefail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,7 +256,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Ensure git in container
         run: |
-          set -euo pipefail
+          set -eu
           if ! command -v git >/dev/null 2>&1; then
             apt-get update
             apt-get install -y git ca-certificates

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,7 +293,13 @@ jobs:
                       });
                       if (string.IsNullOrEmpty(qs))
                           throw new Exception("Encode returned empty string");
-                      Console.WriteLine("SMOKE NET461 OK");
+          #if NET461
+                      Console.WriteLine("SMOKE net461 OK");
+          #elif NET481
+                      Console.WriteLine("SMOKE net481 OK");
+          #else
+                      Console.WriteLine("SMOKE NETFX OK");
+          #endif
                       return 0;
                   }
                   catch (Exception ex)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,13 +249,19 @@ jobs:
     name: Consumer smoke (netcoreapp3.1 compile-only)
     needs: lint
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/dotnet/sdk:3.1
     continue-on-error: true
     steps:
       - uses: actions/checkout@v5
-      - name: Setup .NET 3.1 SDK (non-blocking)
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '3.1.x'
+      - name: Ensure git in container
+        run: |
+          set -euo pipefail
+          if ! command -v git >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y git ca-certificates
+            rm -rf /var/lib/apt/lists/*
+          fi
       - name: Create consumer project (netcoreapp3.1)
         run: |
           set -euo pipefail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,6 @@ jobs:
     name: Ensure compatibility with qs (JS vs C#)
     needs: lint
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -130,12 +129,83 @@ jobs:
             node.out
             cs.out
             diff.out
+  smoke:
+    name: Consumer smoke (net6.0; net8.0; net9.0)
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup .NET SDKs (6, 8, 9)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            6.0.x
+            8.0.x
+            9.0.x
+      - name: Create consumer project (multi-target)
+        run: |
+          set -euo pipefail
+          mkdir -p consumer-smoke
+          cat > consumer-smoke/consumer-smoke.csproj <<'XML'
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+              <OutputType>Exe</OutputType>
+              <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+              <Nullable>enable</Nullable>
+              <ImplicitUsings>enable</ImplicitUsings>
+            </PropertyGroup>
+            <ItemGroup>
+              <ProjectReference Include="../QsNet/QsNet.csproj" />
+            </ItemGroup>
+          </Project>
+          XML
+          cat > consumer-smoke/Program.cs <<'CS'
+          using System;
+          using System.Collections.Generic;
+          using QsNet;
+          class P
+          {
+              static int Main()
+              {
+                  try
+                  {
+                      // Decode should not throw and should return a non-null object graph.
+                      var decoded = Qs.Decode("foo[bar]=baz&foo[list][]=a&foo[list][]=b");
+                      // Encode should produce a non-empty query string.
+                      var qs = Qs.Encode(new Dictionary<string, object?> {
+                          ["foo"] = new Dictionary<string, object?> { ["bar"] = "baz" }
+                      });
+                      if (string.IsNullOrEmpty(qs))
+                          throw new Exception("Encode returned empty string");
+                      Console.WriteLine("SMOKE OK");
+                      return 0;
+                  }
+                  catch (Exception ex)
+                  {
+                      Console.Error.WriteLine(ex);
+                      return 1;
+                  }
+              }
+          }
+          CS
+      - name: Restore consumer
+        run: dotnet restore consumer-smoke/consumer-smoke.csproj
+      - name: Build consumer
+        run: dotnet build -c Release consumer-smoke/consumer-smoke.csproj --no-restore
+      - name: Run smoke (net6.0; net8.0; net9.0)
+        run: |
+          set -euo pipefail
+          for f in net6.0 net8.0 net9.0; do
+            echo "Running smoke for $f"
+            dotnet run -c Release --framework "$f" --project consumer-smoke/consumer-smoke.csproj --no-build
+          done
   coverage:
     name: Coverage (merged)
     runs-on: ubuntu-latest
     needs: 
       - test
       - ensure_compatibility
+      - smoke
     steps:
       - uses: actions/checkout@v5
       - name: Setup .NET 8 SDK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -299,7 +299,7 @@ jobs:
       - name: Restore consumer
         run: dotnet restore consumer-core31/consumer-core31.csproj
       - name: Build consumer (compile only)
-        run: dotnet build -c Release consumer-core31/consumer-core31.csproj --no-restore -p:EnableSourceControlManagerQueries=false -p:DeterministicSourcePaths=false -p:SourceLinkCreate=false
+        run: dotnet build -c Release consumer-core31/consumer-core31.csproj --no-restore -p:EnableSourceControlManagerQueries=false -p:DeterministicSourcePaths=false -p:Deterministic=false -p:SourceLinkCreate=false -p:EnableSourceLink=false -p:UseSourceLink=false -p:PublishRepositoryUrl=false -p:EmbedUntrackedSources=false
   smoke_netfx:
     name: Consumer smoke (.NET Framework 4.6.1 & 4.8.1 on Windows)
     needs: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,6 +205,70 @@ jobs:
             echo "Running smoke for $f"
             dotnet run -c Release --framework "$f" --project consumer-smoke/consumer-smoke.csproj --no-build
           done
+  smoke_netfx:
+    name: Consumer smoke (.NET Framework 4.6.1 on Windows)
+    needs: lint
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+      - name: Create consumer project (net461)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p consumer-netfx
+          cat > consumer-netfx/consumer-netfx.csproj <<'XML'
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+              <OutputType>Exe</OutputType>
+              <TargetFramework>net461</TargetFramework>
+              <Nullable>disable</Nullable>
+              <ImplicitUsings>false</ImplicitUsings>
+              <LangVersion>7.3</LangVersion>
+            </PropertyGroup>
+            <ItemGroup>
+              <ProjectReference Include="../QsNet/QsNet.csproj" />
+              <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+            </ItemGroup>
+          </Project>
+          XML
+          cat > consumer-netfx/Program.cs <<'CS'
+          using System;
+          using System.Collections.Generic;
+          using QsNet;
+          class P
+          {
+              static int Main()
+              {
+                  try
+                  {
+                      var decoded = Qs.Decode("foo[bar]=baz&foo[list][]=a&foo[list][]=b");
+                      var qs = Qs.Encode(new Dictionary<string, object?> {
+                          ["foo"] = new Dictionary<string, object?> { ["bar"] = "baz" }
+                      });
+                      if (string.IsNullOrEmpty(qs))
+                          throw new Exception("Encode returned empty string");
+                      Console.WriteLine("SMOKE NET461 OK");
+                      return 0;
+                  }
+                  catch (Exception ex)
+                  {
+                      Console.Error.WriteLine(ex);
+                      return 1;
+                  }
+              }
+          }
+          CS
+      - name: Restore consumer
+        run: dotnet restore consumer-netfx/consumer-netfx.csproj
+      - name: Build consumer
+        run: dotnet build -c Release consumer-netfx/consumer-netfx.csproj --no-restore
+      - name: Run smoke (net461)
+        run: dotnet run -c Release --framework net461 --project consumer-netfx/consumer-netfx.csproj --no-build
   coverage:
     name: Coverage (merged)
     runs-on: ubuntu-latest
@@ -212,6 +276,7 @@ jobs:
       - test
       - ensure_compatibility
       - smoke
+      - smoke_netfx
     steps:
       - uses: actions/checkout@v5
       - name: Setup .NET 8 SDK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -299,7 +299,7 @@ jobs:
       - name: Restore consumer
         run: dotnet restore consumer-core31/consumer-core31.csproj
       - name: Build consumer (compile only)
-        run: dotnet build -c Release consumer-core31/consumer-core31.csproj --no-restore
+        run: dotnet build -c Release consumer-core31/consumer-core31.csproj --no-restore -p:EnableSourceControlManagerQueries=false -p:DeterministicSourcePaths=false -p:SourceLinkCreate=false
   smoke_netfx:
     name: Consumer smoke (.NET Framework 4.6.1 & 4.8.1 on Windows)
     needs: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,7 +264,7 @@ jobs:
           fi
       - name: Create consumer project (netcoreapp3.1)
         run: |
-          set -euo pipefail
+          set -eu
           mkdir -p consumer-core31
           cat > consumer-core31/consumer-core31.csproj <<'XML'
           <Project Sdk="Microsoft.NET.Sdk">

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,15 @@ jobs:
         run: dotnet format --verify-no-changes --verbosity minimal
       - name: Build (warnings -> errors)
         run: dotnet build --configuration Release -p:TreatWarningsAsErrors=true --no-restore
+      - name: Pack NuGet (artifact for smoke_netcore31)
+        run: |
+          dotnet pack QsNet/QsNet.csproj -c Release -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=false -p:Version=0.0.0-ci -o $RUNNER_TEMP/nupkg
+      - name: Upload nupkg artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qsnet-nupkg
+          path: ${{ runner.temp }}/nupkg/*.nupkg
+          retention-days: 1
   test:
     name: Test ${{ matrix.dotnet }} on ${{ matrix.os }}
     needs: lint
@@ -254,6 +263,11 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v5
+      - name: Download nupkg
+        uses: actions/download-artifact@v4
+        with:
+          name: qsnet-nupkg
+          path: ./nupkg
       - name: Ensure git in container
         run: |
           set -eu
@@ -273,9 +287,10 @@ jobs:
               <TargetFramework>netcoreapp3.1</TargetFramework>
               <Nullable>enable</Nullable>
               <ImplicitUsings>false</ImplicitUsings>
+              <LangVersion>8.0</LangVersion>
             </PropertyGroup>
             <ItemGroup>
-              <ProjectReference Include="../QsNet/QsNet.csproj" />
+              <PackageReference Include="QsNet" Version="0.0.0-ci" />
             </ItemGroup>
           </Project>
           XML
@@ -297,9 +312,9 @@ jobs:
           }
           CS
       - name: Restore consumer
-        run: dotnet restore consumer-core31/consumer-core31.csproj
+        run: dotnet restore consumer-core31/consumer-core31.csproj --source ./nupkg --source https://api.nuget.org/v3/index.json
       - name: Build consumer (compile only)
-        run: dotnet build -c Release consumer-core31/consumer-core31.csproj --no-restore -p:EnableSourceControlManagerQueries=false -p:DeterministicSourcePaths=false -p:Deterministic=false -p:SourceLinkCreate=false -p:EnableSourceLink=false -p:UseSourceLink=false -p:PublishRepositoryUrl=false -p:EmbedUntrackedSources=false
+        run: dotnet build -c Release consumer-core31/consumer-core31.csproj --no-restore
   smoke_netfx:
     name: Consumer smoke (.NET Framework 4.6.1 & 4.8.1 on Windows)
     needs: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,7 +256,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-      - name: Create consumer project (net461)
+      - name: Create consumer project (net461 & net481)
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,12 @@ jobs:
             6.0.x
             8.0.x
             9.0.x
+      - name: Setup .NET 10 preview SDK (non-blocking)
+        continue-on-error: true
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          dotnet-quality: preview
       - name: Create consumer project (multi-target)
         run: |
           set -euo pipefail
@@ -151,7 +157,7 @@ jobs:
           <Project Sdk="Microsoft.NET.Sdk">
             <PropertyGroup>
               <OutputType>Exe</OutputType>
-              <TargetFrameworks>net5.0;net6.0;net8.0;net9.0</TargetFrameworks>
+              <TargetFrameworks>net5.0;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
               <Nullable>enable</Nullable>
               <ImplicitUsings>false</ImplicitUsings>
             </PropertyGroup>
@@ -191,8 +197,23 @@ jobs:
           CS
       - name: Restore consumer
         run: dotnet restore consumer-smoke/consumer-smoke.csproj
-      - name: Build consumer
-        run: dotnet build -c Release consumer-smoke/consumer-smoke.csproj --no-restore
+      - name: Build consumer (net6.0; net8.0; net9.0)
+        run: |
+          set -euo pipefail
+          for f in net6.0 net8.0 net9.0; do
+            echo "Building $f"
+            dotnet build -c Release -f "$f" consumer-smoke/consumer-smoke.csproj --no-restore
+          done
+      - name: Build consumer (net5.0 — non-blocking)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          dotnet build -c Release -f net5.0 consumer-smoke/consumer-smoke.csproj --no-restore
+      - name: Build consumer (net10.0 preview — non-blocking)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          dotnet build -c Release -f net10.0 consumer-smoke/consumer-smoke.csproj --no-restore
       - name: Run smoke (net5.0 — non-blocking)
         continue-on-error: true
         run: |
@@ -205,6 +226,11 @@ jobs:
             echo "Running smoke for $f"
             dotnet run -c Release --framework "$f" --project consumer-smoke/consumer-smoke.csproj --no-build
           done
+      - name: Run smoke (net10.0 preview — non-blocking)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          dotnet run -c Release --framework net10.0 --project consumer-smoke/consumer-smoke.csproj --no-build
   smoke_netfx:
     name: Consumer smoke (.NET Framework 4.6.1 on Windows)
     needs: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
             cs.out
             diff.out
   smoke:
-    name: Consumer smoke (net5.0; net6.0; net8.0; net9.0)
+    name: Consumer smoke (net5.0; net6.0; net7.0; net8.0; net9.0)
     needs: lint
     runs-on: ubuntu-latest
     steps:
@@ -243,10 +243,10 @@ jobs:
         run: |
           set -euo pipefail
           dotnet run -c Release --framework net5.0 --project consumer-smoke/consumer-smoke.csproj --no-build
-      - name: Run smoke (net6.0; net8.0; net9.0)
+      - name: Run smoke (net6.0; net7.0; net8.0; net9.0)
         run: |
           set -euo pipefail
-          for f in net6.0 net8.0 net9.0; do
+          for f in net6.0 net7.0 net8.0 net9.0; do
             echo "Running smoke for $f"
             dotnet run -c Release --framework "$f" --project consumer-smoke/consumer-smoke.csproj --no-build
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
               <OutputType>Exe</OutputType>
               <TargetFrameworks>net5.0;net6.0;net8.0;net9.0</TargetFrameworks>
               <Nullable>enable</Nullable>
-              <ImplicitUsings>enable</ImplicitUsings>
+              <ImplicitUsings>false</ImplicitUsings>
             </PropertyGroup>
             <ItemGroup>
               <ProjectReference Include="../QsNet/QsNet.csproj" />

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,8 +271,8 @@ jobs:
       - name: Verify local nupkg
         run: |
           set -eu
-          echo "Listing ${{ github.workspace }}/nupkg";
-          ls -la "${{ github.workspace }}/nupkg" || { echo "nupkg directory missing"; exit 1; }
+          echo "Listing $GITHUB_WORKSPACE/nupkg";
+          ls -la "$GITHUB_WORKSPACE/nupkg" || { echo "nupkg directory missing"; exit 1; }
       - name: Ensure git in container
         run: |
           set -eu
@@ -317,7 +317,7 @@ jobs:
           }
           CS
       - name: Restore consumer
-        run: dotnet restore consumer-core31/consumer-core31.csproj --source "${{ github.workspace }}/nupkg" --source https://api.nuget.org/v3/index.json
+        run: dotnet restore consumer-core31/consumer-core31.csproj --source "$GITHUB_WORKSPACE/nupkg" --source https://api.nuget.org/v3/index.json
       - name: Build consumer (compile only)
         run: dotnet build -c Release consumer-core31/consumer-core31.csproj --no-restore
   smoke_netfx:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,9 +226,9 @@ jobs:
             <PropertyGroup>
               <OutputType>Exe</OutputType>
               <TargetFramework>net461</TargetFramework>
-              <Nullable>disable</Nullable>
+              <Nullable>enable</Nullable>
               <ImplicitUsings>false</ImplicitUsings>
-              <LangVersion>7.3</LangVersion>
+              <LangVersion>8.0</LangVersion>
             </PropertyGroup>
             <ItemGroup>
               <ProjectReference Include="../QsNet/QsNet.csproj" />

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   workflow_call:
-    
+
 permissions:
   contents: read
 
@@ -397,7 +397,7 @@ jobs:
   coverage:
     name: Coverage (merged)
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - test
       - ensure_compatibility
       - smoke

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ dotnet add package QsNet
 
 ## Requirements
 
-- **Target frameworks:** `net8.0`, `netstandard2.0`
-- **Supported runtimes (via the TFMs above):**
+- **Target frameworks (TFMs):** `net8.0`, `netstandard2.0`
+- **Supported runtimes (via the target frameworks above):**
 
 | Runtime        | Version      | CI Coverage                          | Status    |
 |----------------|--------------|--------------------------------------|-----------|

--- a/README.md
+++ b/README.md
@@ -59,15 +59,19 @@ dotnet add package QsNet
 
 - **Target frameworks:** `net8.0`, `netstandard2.0`
 - **Supported runtimes (via the TFMs above):**
-  - **.NET 10 (preview)** — covered in CI (non-blocking)
-  - **.NET 9 (STS)** — covered in CI
-  - **.NET 8 (LTS)** — covered in CI
-  - **.NET 7** — consumer smoke tested
-  - **.NET 6 (LTS)** — consumer smoke tested
-  - **.NET 5** — optional smoke (non-blocking / EOL)
-  - **.NET Core 3.1** — compile-only smoke in container (EOL)
-  - **.NET Framework** — **4.6.1** and **4.8.1** smoke tested; any **4.6.1+** is compatible via `netstandard2.0`
-  - **Platforms:** Windows, Linux, macOS (pure managed; no native dependencies)
+
+| Runtime        | Version      | CI Coverage                          | Status    |
+|----------------|--------------|--------------------------------------|-----------|
+| .NET           | 10 (preview) | Full CI (experimental; non-blocking) | Preview   |
+| .NET           | 9 (STS)      | Full CI                              | Supported |
+| .NET           | 8 (LTS)      | Full CI                              | Supported |
+| .NET           | 7            | Consumer smoke test                  | Supported |
+| .NET           | 6 (LTS)      | Consumer smoke test                  | Supported |
+| .NET           | 5            | Optional smoke (non-blocking)        | EOL       |
+| .NET Core      | 3.1          | Compile-only smoke                   | EOL       |
+| .NET Framework | 4.6.1+       | Smoke test (4.6.1, 4.8.1)            | Supported |
+
+- **Platforms:** Windows, Linux, macOS (cross-platform, no native dependencies)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A query string encoding and decoding library for C#/.NET.
 
 Ported from [qs](https://www.npmjs.com/package/qs) for JavaScript.
 
-[![Targets](https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftechouse%2Fqs-net%2Fmain%2FQsNet%2FQsNet.csproj&query=string(//TargetFrameworks|//TargetFramework)&label=targets&logo=dotnet&color=512BD4&labelColor=222222&logoColor=white&style=flat-square&link=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FQsNet)](https://www.nuget.org/packages/QsNet)
+[![Targets](https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftechouse%2Fqs-net%2Fmain%2FQsNet%2FQsNet.csproj&query=string(//TargetFrameworks%7C//TargetFramework)&label=targets&logo=dotnet&color=512BD4&labelColor=222222&logoColor=white&style=flat-square)](https://www.nuget.org/packages/QsNet)
 [![DocFX Docs](https://img.shields.io/badge/DocFX-docs-512BD4?logo=dotnet&logoColor=white&labelColor=222222&style=flat-square)](https://techouse.github.io/qs-net/)
 [![NuGet Version](https://img.shields.io/nuget/v/QsNet)](https://www.nuget.org/packages/QsNet)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/QsNet)](https://www.nuget.org/packages/QsNet)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A query string encoding and decoding library for C#/.NET.
 
 Ported from [qs](https://www.npmjs.com/package/qs) for JavaScript.
 
-[![Targets](https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftechouse%2Fqs-net%2Fmain%2FQsNet%2FQsNet.csproj&query=string(//TargetFrameworks|//TargetFramework)&label=targets&logo=dotnet&color=512BD4&labelColor=222222&logoColor=white&style=flat-square&link=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FQsNet)]((https://www.nuget.org/packages/QsNet))
+[![Targets](https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftechouse%2Fqs-net%2Fmain%2FQsNet%2FQsNet.csproj&query=string(//TargetFrameworks|//TargetFramework)&label=targets&logo=dotnet&color=512BD4&labelColor=222222&logoColor=white&style=flat-square&link=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FQsNet)](https://www.nuget.org/packages/QsNet)
 [![DocFX Docs](https://img.shields.io/badge/DocFX-docs-512BD4?logo=dotnet&logoColor=white&labelColor=222222&style=flat-square)](https://techouse.github.io/qs-net/)
 [![NuGet Version](https://img.shields.io/nuget/v/QsNet)](https://www.nuget.org/packages/QsNet)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/QsNet)](https://www.nuget.org/packages/QsNet)
@@ -57,7 +57,17 @@ dotnet add package QsNet
 
 ## Requirements
 
-- **Targets:** `net8.0`, `netstandard2.0`
+- **Target frameworks:** `net8.0`, `netstandard2.0`
+- **Supported runtimes (via the TFMs above):**
+  - **.NET 10 (preview)** — covered in CI (non-blocking)
+  - **.NET 9 (STS)** — covered in CI
+  - **.NET 8 (LTS)** — covered in CI
+  - **.NET 7** — consumer smoke tested
+  - **.NET 6 (LTS)** — consumer smoke tested
+  - **.NET 5** — optional smoke (non-blocking / EOL)
+  - **.NET Core 3.1** — compile-only smoke in container (EOL)
+  - **.NET Framework** — **4.6.1** and **4.8.1** smoke tested; any **4.6.1+** is compatible via `netstandard2.0`
+  - **Platforms:** Windows, Linux, macOS (pure managed; no native dependencies)
 
 ---
 


### PR DESCRIPTION
This pull request significantly expands and improves the CI workflow defined in `.github/workflows/test.yml`. The main changes include broader platform and framework compatibility testing for the `QsNet` library, the introduction of new smoke test jobs for several .NET versions (including legacy and preview), and enhancements to artifact handling for cross-version builds. These updates help ensure that the library builds and runs correctly across a wide range of .NET targets, and that future .NET releases are proactively tested.

**Expanded compatibility and testing:**

* Added new matrix entries and logic to the `test` job to support .NET 10 preview, including conditional setup and marking preview builds as experimental/non-blocking. (.NET SDK setup and matrix changes)
* Added a comprehensive `smoke` job that creates and runs a consumer project targeting net5.0, net6.0, net7.0, net8.0, net9.0, and net10.0, with preview and legacy versions handled as non-blocking.
* Introduced a `smoke_netcore31` job to verify compile-only compatibility with netcoreapp3.1 using a locally packed NuGet artifact, running inside a containerized .NET Core 3.1 environment.
* Added a `smoke_netfx` job to test consumer builds and runs on .NET Framework 4.6.1 and 4.8.1 on Windows, including multi-targeting and reference assemblies setup.

**Artifact packaging and cross-job usage:**

* Added steps to pack the `QsNet` library as a NuGet package and upload it as an artifact for use in downstream jobs (such as `smoke_netcore31`).

**Workflow dependency updates:**

* Updated the `coverage` job to depend on the new smoke test jobs, ensuring coverage is only reported after compatibility checks complete.

These changes provide much greater confidence in the cross-version and cross-platform reliability of the library, and make it easier to catch breaking changes early as new .NET versions are released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with a dynamic Target frameworks badge, renamed “Target frameworks” section, and added a “Supported runtimes” list (covers .NET 5–10 preview, .NET Framework 4.6.1/4.8.1) and platform notes.

* **Bug Fixes**
  * Fixed broken Targets badge link in README.

* **Chores**
  * Expanded CI with multi-target smoke tests (multi-framework, .NET Framework, and compile-only .NET Core 3.1), split stable/preview SDK setup, added experimental matrix runs, published a NuGet artifact for CI, and updated coverage dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->