### PR TITLE
:zap: optimize `ParseQueryStringValues`

### DIFF
--- a/QsNet/Internal/Decoder.cs
+++ b/QsNet/Internal/Decoder.cs
@@ -52,7 +52,7 @@ internal static partial class Decoder
             var idx = str.IndexOf(',');
             if (idx >= 0)
             {
-                var list = new List<object?>(4); // small starting capacity; grows as needed
+                var list = new List<object?>(4); // Initial capacity for typical comma lists (3-5 elements); grows as needed
                 var start = 0;
 
                 while (true)

--- a/QsNet/Internal/Decoder.cs
+++ b/QsNet/Internal/Decoder.cs
@@ -143,6 +143,7 @@ internal static partial class Decoder
                     skipIndex = i;
                     break;
                 }
+        var isLatin1 = IsLatin1(charset);
 
         for (var i = 0; i < parts.Count; i++)
         {
@@ -193,7 +194,7 @@ internal static partial class Decoder
                 value != null
                 && !Utils.IsEmpty(value)
                 && options.InterpretNumericEntities
-                && IsLatin1(charset)
+                && isLatin1
             )
             {
                 var tmpStr = value is IEnumerable enumerable and not string

--- a/QsNet/Internal/Decoder.cs
+++ b/QsNet/Internal/Decoder.cs
@@ -208,16 +208,12 @@ internal static partial class Decoder
                 key = options.DecodeKey(rawKey, charset) ?? string.Empty;
 #endif
                 hadExisting = obj.TryGetValue(key, out existingVal);
-                // Explicit currentLength logic: count a singleton non-list value as 1, null as 0
+                // Only count existing when combining; Last/First do not increase length.
                 var currentLength = 0;
-                if (hadExisting)
+                if (hadExisting && options.Duplicates == Duplicates.Combine)
                 {
-                    if (existingVal is IList<object?> list)
-                        currentLength = list.Count;
-                    else if (existingVal != null)
-                        // Treat a singleton existing value as one element so ListLimit applies correctly
-                        // when combining duplicates (e.g., "a=1&a=2").
-                        currentLength = 1;
+                    if (existingVal is IList<object?> l) currentLength = l.Count;
+                    else if (!Utils.IsEmpty(existingVal)) currentLength = 1;
                 }
 
 #if NETSTANDARD2_0

--- a/QsNet/QsNet.csproj
+++ b/QsNet/QsNet.csproj
@@ -52,6 +52,12 @@
     </ItemGroup>
 
     <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>QsNet.Benchmarks</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     </ItemGroup>
 </Project>

--- a/QsNet/QsNet.csproj
+++ b/QsNet/QsNet.csproj
@@ -49,12 +49,7 @@
         <None Include="..\LICENSE" Pack="true" PackagePath="\"/>
         <None Include="..\logo.png" Pack="true" PackagePath="\"/>
         <InternalsVisibleTo Include="QsNet.Tests"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-            <_Parameter1>QsNet.Benchmarks</_Parameter1>
-        </AssemblyAttribute>
+        <InternalsVisibleTo Include="QsNet.Benchmarks"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/benchmarks/QsNet.Benchmarks/DecodeBenchmarks.cs
+++ b/benchmarks/QsNet.Benchmarks/DecodeBenchmarks.cs
@@ -1,0 +1,109 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using QsNet;
+using QsNet.Models;
+
+// Run on the build TFM by default; add others via --runtimes when installed
+#if NET8_0
+[SimpleJob(RuntimeMoniker.Net80, baseline: true)]
+#elif NET9_0
+[SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+#else
+[SimpleJob(RuntimeMoniker.HostProcess, baseline: true)]
+#endif
+[MemoryDiagnoser]
+[HideColumns("Job", "Error", "StdDev", "Median")]
+public class DecodeBenchmarks
+{
+    // Number of key=value pairs
+    [Params(10, 100, 1000)]
+    public int Count;
+
+    // Include "a,b,c" style list values every Nth item
+    [Params(false, true)]
+    public bool CommaLists;
+
+    // Add utf8 sentinel up front
+    [Params(false, true)]
+    public bool Utf8Sentinel;
+
+    // Average value length (characters)
+    [Params(8, 40)]
+    public int ValueLen;
+
+    private string _query = string.Empty;
+    private DecodeOptions _options = new();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var pairs = new List<string>(Count + (Utf8Sentinel ? 1 : 0));
+        if (Utf8Sentinel)
+        {
+            // The form recognized by qs: "utf8=%E2%9C%93"
+            pairs.Add("utf8=%E2%9C%93");
+        }
+
+        for (int i = 0; i < Count; i++)
+        {
+            var key = $"k{i}";
+            string val;
+            if (CommaLists && i % 10 == 0)
+            {
+                // small comma list
+                val = "a,b,c";
+            }
+            else
+            {
+                val = MakeValue(ValueLen, i);
+            }
+            pairs.Add($"{key}={val}");
+        }
+
+        _query = string.Join('&', pairs);
+
+        _options = new DecodeOptions
+        {
+            // Try toggling these as you like
+            Comma = CommaLists,
+            ParseLists = true,
+            ParameterLimit = int.MaxValue,
+            ThrowOnLimitExceeded = false,
+            InterpretNumericEntities = false,
+            CharsetSentinel = Utf8Sentinel,
+            IgnoreQueryPrefix = false
+        };
+    }
+
+    // Public API baseline
+    [Benchmark(Baseline = true)]
+    public object Decode_Public()
+    {
+        return Qs.Decode(_query, _options);
+    }
+
+    // Internal hot path (requires InternalsVisibleTo)
+    [Benchmark]
+    public object Decode_Internal_ParseQueryStringValues()
+    {
+        return QsNet.Internal.Decoder.ParseQueryStringValues(_query, _options);
+    }
+
+    private static string MakeValue(int length, int seed)
+    {
+        // generate deterministic pseudo-random ascii (letters+digits) without allocations per char
+        var sb = new StringBuilder(length);
+        uint state = (uint)(seed * 2654435761u + 1013904223u);
+        for (int i = 0; i < length; i++)
+        {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            var x = (int)(state % 62);
+            char ch = (char)(x < 10 ? '0' + x : x < 36 ? 'A' + (x - 10) : 'a' + (x - 36));
+            sb.Append(ch);
+        }
+        return sb.ToString();
+    }
+}

--- a/benchmarks/QsNet.Benchmarks/DecodeBenchmarks.cs
+++ b/benchmarks/QsNet.Benchmarks/DecodeBenchmarks.cs
@@ -3,7 +3,67 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using QsNet;
 using QsNet.Models;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
 
+// Custom column that shows mean time per key=value pair (in ns)
+internal sealed class NsPerPairColumn : IColumn
+{
+    public string Id => nameof(NsPerPairColumn);
+    public string ColumnName => "ns/pair";
+    public string Legend => "Mean nanoseconds per parsed pair (Mean/Count)";
+    public ColumnCategory Category => ColumnCategory.Statistics;
+    public int PriorityInCategory => 100;
+    public bool AlwaysShow => true;
+    public bool IsNumeric => true;
+    public UnitType UnitType => UnitType.Time;
+
+    public string GetValue(Summary summary, BenchmarkCase benchmarkCase)
+        => GetValue(summary, benchmarkCase, summary.Style);
+
+    public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style)
+    {
+        var report = summary[benchmarkCase];
+        var stats = report?.ResultStatistics;
+        if (stats is null)
+            return "-";
+
+        // Benchmark parameter Count (number of key=value pairs)
+        int count = 1;
+        var parameters = benchmarkCase.Parameters.Items;
+        for (int i = 0; i < parameters.Count; i++)
+        {
+            var p = parameters[i];
+            if (p.Name == nameof(DecodeBenchmarks.Count))
+            {
+                count = p.Value is int iv ? iv : Convert.ToInt32(p.Value);
+                break;
+            }
+        }
+
+        if (count <= 0) count = 1;
+
+        // Mean is stored in nanoseconds
+        double nsPerPair = stats.Mean / count;
+        return nsPerPair.ToString("0.##");
+    }
+
+    public bool IsAvailable(Summary summary) => true;
+    public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+}
+
+// Attach our custom column via config
+internal sealed class BenchConfig : ManualConfig
+{
+    public BenchConfig()
+    {
+        AddColumn(new NsPerPairColumn());
+    }
+}
+
+[Config(typeof(BenchConfig))]
 // Run on the build TFM by default; add others via --runtimes when installed
 #if NET8_0
 [SimpleJob(RuntimeMoniker.Net80, baseline: true)]

--- a/benchmarks/QsNet.Benchmarks/Program.cs
+++ b/benchmarks/QsNet.Benchmarks/Program.cs
@@ -1,0 +1,10 @@
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+var config = DefaultConfig.Instance.AddDiagnoser(MemoryDiagnoser.Default);
+
+// If no args were provided, run everything by default
+var effectiveArgs = (args?.Length ?? 0) == 0 ? new[] { "--filter", "*" } : args;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(effectiveArgs, config);

--- a/benchmarks/QsNet.Benchmarks/QsNet.Benchmarks.csproj
+++ b/benchmarks/QsNet.Benchmarks/QsNet.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\QsNet\QsNet.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This pull request introduces a comprehensive benchmarking suite for the `QsNet` library and improves the performance and correctness of query string parsing, especially for comma-separated list values. The most significant changes include the addition of a dedicated benchmarking project with custom metrics, enhancements to the internal decoder logic for more efficient and accurate parsing, and minor project configuration updates.

### Benchmarking Suite Addition

* Added a new `QsNet.Benchmarks` project using BenchmarkDotNet, including a custom column (`NsPerPairColumn`) that reports nanoseconds per parsed key-value pair, and a `DecodeBenchmarks` class that tests various parsing scenarios and options. [[1]](diffhunk://#diff-b1c7fbf819ca2336b4017b82e6077f36935f44eaa2dd541c7dfa12b5708afeb3R1-R169) [[2]](diffhunk://#diff-3711ad0a4d97bf6f4ffbc18e4ef7564a7fb187990eb00787acb7170dd63a4b5eR1-R18)
* Implemented a default benchmark runner in `Program.cs` to execute all benchmarks if no filter is specified, and enabled memory diagnostics for all runs.

### Query String Parsing Improvements

* Optimized comma-separated list parsing in `Decoder.cs` to avoid unnecessary string splits and enforce list limits during parsing, improving both performance and correctness.
* Improved percent-encoding replacement logic by only scanning for replacements when a percent character is present, reducing unnecessary string operations.

### Internal Decoder Logic Enhancements

* Refactored logic to track whether a key already exists in the result object, simplifying handling of duplicate keys and improving code clarity. [[1]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946R175-R184) [[2]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946R195) [[3]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946L162-R207) [[4]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946L198-R242)
* Cached the result of the Latin1 charset check to avoid redundant computations during parsing. [[1]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946R175-R184) [[2]](diffhunk://#diff-31eba0e549245fa7f7c38deb81ac9bce61fd322e947fee0df818c3ef31ecf946L182-R226)

### Project Configuration

* Updated `QsNet.csproj` to allow internal visibility for the new benchmarks project, enabling direct testing of internal methods.

---

### Headline
- **Internal** (`ParseQueryStringValues`): ~5.3% average speed-up across the 24 configs (median 4.9%).
  Peaks: 10–12.7% faster in the heavy cases (Count=1000, esp. `CommaLists=True`|`False` with `ValueLen=8`).
- **Public** (`Decode_Public`): ~3.6% average speed-up (median 3.2%).
  Peaks: ~10.8% faster for Count=1000 with short values.

### A few concrete deltas (baseline → current)
- Internal, 10 / False / False / 40: 2.270 μs → 2.125 μs (6.4% faster)
- Internal, 100 / True / False / 40: 25.202 μs → 23.284 μs (7.6% faster)
- Internal, 1000 / True / False / 8: 216.795 μs → 189.324 μs (12.7% faster)
- Public, 1000 / False / False / 8: 350.768 μs → 313.060 μs (10.8% faster)

### Memory
- Allocated bytes are unchanged across the board (e.g., internal 5.06 KB / 7.88 KB / … remain identical). Minor Gen counts fluctuate as usual but no net increase.

### Bottom line

Roughly ~1.06× faster internally and ~1.04× faster publicly overall, with double-digit wins on the largest workloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster, lower-allocation query decoding with more consistent list/parameter limit enforcement, improved comma-list and percent-encoding handling, and more reliable duplicate-parameter behavior. No public API changes.

* **Chores**
  * Added a BenchmarkDotNet project and executable to measure decode performance and memory.
  * Granted the benchmark project access to internals for accurate profiling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->