### PR TITLE
:sparkles: add `StrictMerge` option and improve list-limit handling in decoder tests

### DIFF
--- a/QsNet.Comparison/js/package.json
+++ b/QsNet.Comparison/js/package.json
@@ -6,6 +6,6 @@
   "license": "BSD-3-Clause",
   "packageManager": "pnpm@11.1.3",
   "dependencies": {
-    "qs": "^6.15.1"
+    "qs": "^6.15.2"
   }
 }

--- a/QsNet.Comparison/js/pnpm-lock.yaml
+++ b/QsNet.Comparison/js/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       qs:
-        specifier: ^6.15.1
-        version: 6.15.1
+        specifier: ^6.15.2
+        version: 6.15.2
 
 packages:
 
@@ -69,8 +69,8 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==, tarball: https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz}
     engines: {node: '>= 0.4'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.1.tgz}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.2.tgz}
     engines: {node: '>=0.6'}
 
   side-channel-list@1.0.1:
@@ -147,7 +147,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/QsNet.Tests/DecodeOptionsTests.cs
+++ b/QsNet.Tests/DecodeOptionsTests.cs
@@ -29,6 +29,7 @@ public class DecodeOptionsTests
             InterpretNumericEntities = true,
             ParameterLimit = 200,
             ParseLists = true,
+            StrictMerge = false,
             StrictNullHandling = true
         };
 
@@ -49,6 +50,7 @@ public class DecodeOptionsTests
         newOptions.InterpretNumericEntities.Should().BeTrue();
         newOptions.ParameterLimit.Should().Be(200);
         newOptions.ParseLists.Should().BeTrue();
+        newOptions.StrictMerge.Should().BeFalse();
         newOptions.StrictNullHandling.Should().BeTrue();
 
         newOptions.Should().BeEquivalentTo(options);
@@ -91,6 +93,7 @@ public class DecodeOptionsTests
             interpretNumericEntities: false,
             parameterLimit: 200,
             parseLists: true,
+            strictMerge: false,
             strictNullHandling: false
         );
 
@@ -108,6 +111,7 @@ public class DecodeOptionsTests
         newOptions.InterpretNumericEntities.Should().BeFalse();
         newOptions.ParameterLimit.Should().Be(200);
         newOptions.ParseLists.Should().BeTrue();
+        newOptions.StrictMerge.Should().BeFalse();
         newOptions.StrictNullHandling.Should().BeFalse();
     }
 

--- a/QsNet.Tests/DecodeTests.cs
+++ b/QsNet.Tests/DecodeTests.cs
@@ -2665,7 +2665,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_Duplicates_BracketNotationAlwaysCombines()
+    public void ShouldCombineDuplicatesWhenUsingBracketNotation()
     {
         Qs.Decode("a=1&a=2&b[]=1&b[]=2", new DecodeOptions { Duplicates = Duplicates.Last })
             .Should()
@@ -2687,7 +2687,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_StrictMerge_DefaultWrapsObjectPrimitiveConflicts()
+    public void ShouldWrapObjectPrimitiveConflictsWhenStrictMergeIsDefault()
     {
         Qs.Decode("a[b]=c&a=d")
             .Should()
@@ -2715,7 +2715,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_StrictMerge_FalseKeepsLegacyObjectThenPrimitiveMerge()
+    public void ShouldKeepLegacyObjectThenPrimitiveMergeWhenStrictMergeIsFalse()
     {
         var options = new DecodeOptions { StrictMerge = false };
 
@@ -2956,7 +2956,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_ListLimit_ThrowsForExplicitIndexAtLimitWhenThrowOn()
+    public void ShouldThrowForExplicitIndexAtListLimitWhenThrowOnLimitExceeded()
     {
         var options = new DecodeOptions { ListLimit = 0, ThrowOnLimitExceeded = true };
 
@@ -4744,7 +4744,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_CommaSplit_CombinesBeforeOverflowWhenIncomingValueIsWithinLimit()
+    public void ShouldCombineBeforeOverflowWhenCommaValueIsWithinLimit()
     {
         var opts = new DecodeOptions
         {
@@ -4769,7 +4769,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_CommaSplit_ConvertsToOverflowMapWhenSumExceedsLimit_AndThrowOff()
+    public void ShouldConvertCommaSplitToOverflowMapWhenCombinedLengthExceedsLimit()
     {
         var opts = new DecodeOptions
         {
@@ -4795,7 +4795,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_CommaSplit_AppendsIncomingValuesToOverflowMapWhenAlreadyAtLimit_AndThrowOff()
+    public void ShouldAppendCommaValuesToOverflowMapWhenAlreadyAtLimit()
     {
         var opts = new DecodeOptions
         {
@@ -4821,7 +4821,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_CommaSplit_BracketedKey_TreatsCommaValueAsOneOuterElement_AndThrowOff()
+    public void ShouldTreatCommaValueAsOneOuterElementWhenBracketedKey()
     {
         var opts = new DecodeOptions
         {
@@ -4863,7 +4863,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_BracketSingle_CommaSplit_DoesNotApplyInnerListLimit()
+    public void ShouldNotApplyInnerListLimitForBracketSingleCommaSplit()
     {
         var opts = new DecodeOptions
         {
@@ -4895,7 +4895,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void EncodedBracketText_DecodesWithoutMungingLiteralPercentSequences()
+    public void ShouldDecodeEncodedBracketTextWithoutMungingLiteralPercentSequences()
     {
         Qs.Decode("a%25255Bb=c")
             .Should()
@@ -5475,7 +5475,7 @@ public partial class DecodeTest
     #region Decode comma limit
 
     [Fact]
-    public void Decode_CommaSplit_AllowedWhenSumEqualsLimit()
+    public void ShouldAllowCommaSplitWhenCombinedLengthEqualsLimit()
     {
         var opts = new DecodeOptions
         {
@@ -5496,7 +5496,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_CommaSplit_ThrowsWhenSumExceedsLimitAndThrowOn()
+    public void ShouldThrowWhenCommaSplitCombinedLengthExceedsLimitAndThrowOn()
     {
         var opts = new DecodeOptions
         {

--- a/QsNet.Tests/DecodeTests.cs
+++ b/QsNet.Tests/DecodeTests.cs
@@ -1182,29 +1182,29 @@ public partial class DecodeTest
     [Fact]
     public void Decode_LimitsSpecificListIndices_ToListLimit()
     {
-        Qs.Decode("a[20]=a", new DecodeOptions { ListLimit = 20 })
+        Qs.Decode("a[19]=a", new DecodeOptions { ListLimit = 20 })
             .Should()
             .BeEquivalentTo(new Dictionary<string, object?> { ["a"] = new List<object?> { "a" } });
 
-        Qs.Decode("a[21]=a", new DecodeOptions { ListLimit = 20 })
+        Qs.Decode("a[20]=a", new DecodeOptions { ListLimit = 20 })
             .Should()
             .BeEquivalentTo(
                 new Dictionary<string, object?>
                 {
-                    ["a"] = new Dictionary<string, object?> { ["21"] = "a" }
+                    ["a"] = new Dictionary<string, object?> { ["20"] = "a" }
                 }
             );
 
-        Qs.Decode("a[20]=a")
+        Qs.Decode("a[19]=a")
             .Should()
             .BeEquivalentTo(new Dictionary<string, object?> { ["a"] = new List<object?> { "a" } });
 
-        Qs.Decode("a[21]=a")
+        Qs.Decode("a[20]=a")
             .Should()
             .BeEquivalentTo(
                 new Dictionary<string, object?>
                 {
-                    ["a"] = new Dictionary<string, object?> { ["21"] = "a" }
+                    ["a"] = new Dictionary<string, object?> { ["20"] = "a" }
                 }
             );
     }
@@ -1214,7 +1214,11 @@ public partial class DecodeTest
     {
         Qs.Decode("a[2]=x", new DecodeOptions { ListLimit = 2 })
             .Should()
-            .BeEquivalentTo(new Dictionary<string, object?> { ["a"] = new List<object?> { "x" } });
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = new Dictionary<string, object?> { ["2"] = "x" }
+                });
 
         Qs.Decode("a[]=1&a[]=2&a[]=3", new DecodeOptions { ListLimit = 2 })
             .Should()
@@ -1832,7 +1836,12 @@ public partial class DecodeTest
 
         Qs.Decode("a[0]=b", new DecodeOptions { ListLimit = 0 })
             .Should()
-            .BeEquivalentTo(new Dictionary<string, object?> { ["a"] = new List<object?> { "b" } });
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = new Dictionary<string, object?> { ["0"] = "b" }
+                }
+            );
 
         Qs.Decode("a[-1]=b", new DecodeOptions { ListLimit = -1 })
             .Should()
@@ -2656,6 +2665,82 @@ public partial class DecodeTest
     }
 
     [Fact]
+    public void Decode_Duplicates_BracketNotationAlwaysCombines()
+    {
+        Qs.Decode("a=1&a=2&b[]=1&b[]=2", new DecodeOptions { Duplicates = Duplicates.Last })
+            .Should()
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = "2",
+                    ["b"] = new List<object?> { "1", "2" }
+                });
+
+        Qs.Decode("a=1&a=2&b[]=1&b[]=2", new DecodeOptions { Duplicates = Duplicates.First })
+            .Should()
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = "1",
+                    ["b"] = new List<object?> { "1", "2" }
+                });
+    }
+
+    [Fact]
+    public void Decode_StrictMerge_DefaultWrapsObjectPrimitiveConflicts()
+    {
+        Qs.Decode("a[b]=c&a=d")
+            .Should()
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = new List<object?>
+                    {
+                        new Dictionary<string, object?> { ["b"] = "c" },
+                        "d"
+                    }
+                });
+
+        Qs.Decode("a=d&a[b]=c")
+            .Should()
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = new List<object?>
+                    {
+                        "d",
+                        new Dictionary<string, object?> { ["b"] = "c" }
+                    }
+                });
+    }
+
+    [Fact]
+    public void Decode_StrictMerge_FalseKeepsLegacyObjectThenPrimitiveMerge()
+    {
+        var options = new DecodeOptions { StrictMerge = false };
+
+        Qs.Decode("a[b]=c&a=d", options)
+            .Should()
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = new Dictionary<string, object?>
+                    {
+                        ["b"] = "c",
+                        ["d"] = true
+                    }
+                });
+
+        Qs.Decode("a[b]=c&a=", options)
+            .Should()
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = new Dictionary<string, object?> { ["b"] = "c" }
+                });
+    }
+
+    [Fact]
     public void Decode_StrictDepth_ThrowsExceptionForMultipleNestedObjectsWithStrictDepthTrue()
     {
         var options = new DecodeOptions { Depth = 1, StrictDepth = true };
@@ -2868,6 +2953,18 @@ public partial class DecodeTest
 
         Action act = () => Qs.Decode("a[]=1&a[]=2&a[]=3&a[]=4", options);
         act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Decode_ListLimit_ThrowsForExplicitIndexAtLimitWhenThrowOn()
+    {
+        var options = new DecodeOptions { ListLimit = 0, ThrowOnLimitExceeded = true };
+
+        Action explicitIndex = () => Qs.Decode("a[0]=b", options);
+        explicitIndex.Should().Throw<InvalidOperationException>();
+
+        Action bracketPush = () => Qs.Decode("a[]=b", options);
+        bracketPush.Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
@@ -3433,29 +3530,29 @@ public partial class DecodeTest
         var options = new DecodeOptions();
         var options20 = new DecodeOptions { ListLimit = 20 };
 
-        Qs.Decode("a[20]=a", options20)
+        Qs.Decode("a[19]=a", options20)
             .Should()
             .BeEquivalentTo(new Dictionary<string, object?> { ["a"] = new List<object?> { "a" } });
 
-        Qs.Decode("a[21]=a", options20)
+        Qs.Decode("a[20]=a", options20)
             .Should()
             .BeEquivalentTo(
                 new Dictionary<string, object?>
                 {
-                    ["a"] = new Dictionary<string, object?> { ["21"] = "a" }
+                    ["a"] = new Dictionary<string, object?> { ["20"] = "a" }
                 }
             );
 
-        Qs.Decode("a[20]=a", options)
+        Qs.Decode("a[19]=a", options)
             .Should()
             .BeEquivalentTo(new Dictionary<string, object?> { ["a"] = new List<object?> { "a" } });
 
-        Qs.Decode("a[21]=a", options)
+        Qs.Decode("a[20]=a", options)
             .Should()
             .BeEquivalentTo(
                 new Dictionary<string, object?>
                 {
-                    ["a"] = new Dictionary<string, object?> { ["21"] = "a" }
+                    ["a"] = new Dictionary<string, object?> { ["20"] = "a" }
                 }
             );
     }
@@ -4402,7 +4499,7 @@ public partial class DecodeTest
     [Fact]
     public void ShouldAddKeysToObjects()
     {
-        var options = new DecodeOptions();
+        var options = new DecodeOptions { StrictMerge = false };
 
         Qs.Decode("a[b]=c&a=d", options)
             .Should()
@@ -4647,7 +4744,32 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_CommaSplit_TruncatesWhenSumExceedsLimit_AndThrowOff()
+    public void Decode_CommaSplit_CombinesBeforeOverflowWhenIncomingValueIsWithinLimit()
+    {
+        var opts = new DecodeOptions
+        {
+            Comma = true,
+            ListLimit = 3,
+            ThrowOnLimitExceeded = false,
+            ParseLists = true,
+            Duplicates = Duplicates.Combine
+        };
+
+        var result = Qs.Decode("a=1&a=2,3,4", opts);
+
+        var dict = Assert.IsType<Dictionary<string, object?>>(result);
+        var map = Assert.IsAssignableFrom<IDictionary<string, object?>>(dict["a"]);
+        map.Should().BeEquivalentTo(new Dictionary<string, object?>
+        {
+            ["0"] = "1",
+            ["1"] = "2",
+            ["2"] = "3",
+            ["3"] = "4"
+        });
+    }
+
+    [Fact]
+    public void Decode_CommaSplit_ConvertsToOverflowMapWhenSumExceedsLimit_AndThrowOff()
     {
         var opts = new DecodeOptions
         {
@@ -4661,12 +4783,19 @@ public partial class DecodeTest
         var result = Qs.Decode("a=1,2&a=3,4,5", opts);
 
         var dict = Assert.IsType<Dictionary<string, object?>>(result);
-        var list = Assert.IsType<List<object?>>(dict["a"]);
-        list.Select(x => x?.ToString()).Should().Equal("1", "2", "3");
+        var map = Assert.IsAssignableFrom<IDictionary<string, object?>>(dict["a"]);
+        map.Should().BeEquivalentTo(new Dictionary<string, object?>
+        {
+            ["0"] = "1",
+            ["1"] = "2",
+            ["2"] = "3",
+            ["3"] = "4",
+            ["4"] = "5"
+        });
     }
 
     [Fact]
-    public void Decode_CommaSplit_DropsIncomingValuesWhenAlreadyAtLimit_AndThrowOff()
+    public void Decode_CommaSplit_AppendsIncomingValuesToOverflowMapWhenAlreadyAtLimit_AndThrowOff()
     {
         var opts = new DecodeOptions
         {
@@ -4680,12 +4809,19 @@ public partial class DecodeTest
         var result = Qs.Decode("a=1,2,3&a=4,5", opts);
 
         var dict = Assert.IsType<Dictionary<string, object?>>(result);
-        var list = Assert.IsType<List<object?>>(dict["a"]);
-        list.Select(x => x?.ToString()).Should().Equal("1", "2", "3");
+        var map = Assert.IsAssignableFrom<IDictionary<string, object?>>(dict["a"]);
+        map.Should().BeEquivalentTo(new Dictionary<string, object?>
+        {
+            ["0"] = "1",
+            ["1"] = "2",
+            ["2"] = "3",
+            ["3"] = "4",
+            ["4"] = "5"
+        });
     }
 
     [Fact]
-    public void Decode_CommaSplit_BracketedKey_DropsIncomingWhenListAlreadyAtLimit_AndThrowOff()
+    public void Decode_CommaSplit_BracketedKey_TreatsCommaValueAsOneOuterElement_AndThrowOff()
     {
         var opts = new DecodeOptions
         {
@@ -4699,8 +4835,11 @@ public partial class DecodeTest
         var result = Qs.Decode("a[]=1&a[]=2&a[]=3,4", opts);
 
         var dict = Assert.IsType<Dictionary<string, object?>>(result);
-        var list = Assert.IsType<List<object?>>(dict["a"]);
-        list.Select(x => x?.ToString()).Should().Equal("1", "2");
+        var map = Assert.IsAssignableFrom<IDictionary<string, object?>>(dict["a"]);
+        map["0"].Should().Be("1");
+        map["1"].Should().Be("2");
+        var nested = Assert.IsType<List<object?>>(map["2"]);
+        nested.Select(x => x?.ToString()).Should().Equal("3", "4");
     }
 
     [Fact]
@@ -4723,6 +4862,22 @@ public partial class DecodeTest
         inner.Select(x => x?.ToString()).Should().Equal("1", "2", "3");
     }
 
+    [Fact]
+    public void Decode_BracketSingle_CommaSplit_DoesNotApplyInnerListLimit()
+    {
+        var opts = new DecodeOptions
+        {
+            Comma = true,
+            ListLimit = 1,
+            ThrowOnLimitExceeded = true
+        };
+
+        var decoded = Assert.IsType<Dictionary<string, object?>>(Qs.Decode("foo[]=1,2,3,4", opts));
+        var outer = Assert.IsType<List<object?>>(decoded["foo"]);
+        var inner = Assert.IsType<List<object?>>(outer[0]);
+        inner.Select(x => x?.ToString()).Should().Equal("1", "2", "3", "4");
+    }
+
     #region Nested brackets
 
     [Fact]
@@ -4736,6 +4891,26 @@ public partial class DecodeTest
                     {
                         ["b[]"] = "c"
                     }
+                });
+    }
+
+    [Fact]
+    public void EncodedBracketText_DecodesWithoutMungingLiteralPercentSequences()
+    {
+        Qs.Decode("a%25255Bb=c")
+            .Should()
+            .BeEquivalentTo(new Dictionary<string, object?> { ["a%255Bb"] = "c" });
+
+        Qs.Decode("a%25255Db=c")
+            .Should()
+            .BeEquivalentTo(new Dictionary<string, object?> { ["a%255Db"] = "c" });
+
+        Qs.Decode("a%5Bb%25255Bc%5D=d")
+            .Should()
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = new Dictionary<string, object?> { ["b%255Bc"] = "d" }
                 });
     }
 
@@ -5388,7 +5563,7 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void Decode_GHSA_w7fw_mjwx_w883_CommaExceedsLimit_ThrowOff_Truncates()
+    public void Decode_GHSA_w7fw_mjwx_w883_CommaExceedsLimit_ThrowOff_ConvertsToOverflowMap()
     {
         var opts = new DecodeOptions
         {
@@ -5398,14 +5573,19 @@ public partial class DecodeTest
         };
 
         var decoded = Assert.IsType<Dictionary<string, object?>>(Qs.Decode("a=1,2,3,4", opts));
-        var list = Assert.IsType<List<object?>>(decoded["a"]);
+        var map = Assert.IsAssignableFrom<IDictionary<string, object?>>(decoded["a"]);
 
-        // Intentional divergence from JS qs: keep allocation bounded by truncating.
-        list.Select(x => x?.ToString()).Should().Equal("1", "2", "3");
+        map.Should().BeEquivalentTo(new Dictionary<string, object?>
+        {
+            ["0"] = "1",
+            ["1"] = "2",
+            ["2"] = "3",
+            ["3"] = "4"
+        });
     }
 
     [Fact]
-    public void Decode_GHSA_w7fw_mjwx_w883_LargeCommaPayload_RespectsListLimitBound()
+    public void Decode_GHSA_w7fw_mjwx_w883_CommaOverflowPreservesAllValues()
     {
         var opts = new DecodeOptions
         {
@@ -5414,12 +5594,13 @@ public partial class DecodeTest
             ThrowOnLimitExceeded = false
         };
 
-        var payload = "a=" + new string(',', 10_000);
+        var payload = "a=1,2,3,4,5,6";
 
         var decoded = Assert.IsType<Dictionary<string, object?>>(Qs.Decode(payload, opts));
-        var list = Assert.IsType<List<object?>>(decoded["a"]);
+        var map = Assert.IsAssignableFrom<IDictionary<string, object?>>(decoded["a"]);
 
-        list.Should().HaveCount(5);
+        map.Should().HaveCount(6);
+        map["5"].Should().Be("6");
     }
 
     #endregion

--- a/QsNet.Tests/DecodeTests.cs
+++ b/QsNet.Tests/DecodeTests.cs
@@ -4744,6 +4744,59 @@ public partial class DecodeTest
     }
 
     [Fact]
+    public void ShouldAppendIncomingCommaOverflowAsSingleElementWhenExistingValueIsList()
+    {
+        var opts = new DecodeOptions
+        {
+            Comma = true,
+            ListLimit = 3,
+            ThrowOnLimitExceeded = false,
+            ParseLists = true,
+            Duplicates = Duplicates.Combine
+        };
+
+        var result = Qs.Decode("a=1,2&a=3,4,5,6", opts);
+
+        var dict = Assert.IsType<Dictionary<string, object?>>(result);
+        var list = Assert.IsType<List<object?>>(dict["a"]);
+        list[0].Should().Be("1");
+        list[1].Should().Be("2");
+
+        var overflow = Assert.IsAssignableFrom<IDictionary<string, object?>>(list[2]);
+        overflow.Should().BeEquivalentTo(new Dictionary<string, object?>
+        {
+            ["0"] = "3",
+            ["1"] = "4",
+            ["2"] = "5",
+            ["3"] = "6"
+        });
+    }
+
+    [Fact]
+    public void ShouldAppendCommaListAsSingleElementWhenExistingValueIsOverflowMap()
+    {
+        var opts = new DecodeOptions
+        {
+            Comma = true,
+            ListLimit = 2,
+            ThrowOnLimitExceeded = false,
+            ParseLists = true,
+            Duplicates = Duplicates.Combine
+        };
+
+        var result = Qs.Decode("a=1,2,3&a=4,5", opts);
+
+        var dict = Assert.IsType<Dictionary<string, object?>>(result);
+        var map = Assert.IsAssignableFrom<IDictionary<string, object?>>(dict["a"]);
+        map["0"].Should().Be("1");
+        map["1"].Should().Be("2");
+        map["2"].Should().Be("3");
+
+        var nested = Assert.IsType<List<object?>>(map["3"]);
+        nested.Select(x => x?.ToString()).Should().Equal("4", "5");
+    }
+
+    [Fact]
     public void ShouldCombineBeforeOverflowWhenCommaValueIsWithinLimit()
     {
         var opts = new DecodeOptions

--- a/QsNet.Tests/EncodeTests.cs
+++ b/QsNet.Tests/EncodeTests.cs
@@ -5336,7 +5336,7 @@ public class EncodeTests
     }
 
     [Fact]
-    public void ShouldUseAmpersandBeforeBodyWhenCharsetSentinelWithCustomDelimiter()
+    public void ShouldUseConfiguredDelimiterBeforeBodyWhenCharsetSentinelWithCustomDelimiter()
     {
         var data = new Dictionary<string, object?>
         {
@@ -5352,7 +5352,7 @@ public class EncodeTests
                 CharsetSentinel = true,
                 Delimiter = ";"
             }
-        ).Should().Be("utf8=%E2%9C%93&a=b;c=d");
+        ).Should().Be("utf8=%E2%9C%93;a=b;c=d");
     }
 
     [Fact]
@@ -5909,6 +5909,75 @@ public class EncodeTests
 
             return current;
         }
+    }
+
+    [Fact]
+    public void Encode_StrictNullHandling_FormatsRfc1738BareKey()
+    {
+        Qs.Encode(
+                new Dictionary<string, object?> { ["a b"] = null },
+                new EncodeOptions { StrictNullHandling = true, Format = Format.Rfc1738 }
+            )
+            .Should()
+            .Be("a+b");
+    }
+
+    [Fact]
+    public void Encode_FilterIterable_SkipsNullEntries()
+    {
+        Qs.Encode(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = "b",
+                    ["null"] = "x",
+                    ["c"] = "d"
+                },
+                new EncodeOptions { Filter = new IterableFilter(new object?[] { "a", null, "c" }) }
+            )
+            .Should()
+            .Be("a=b&c=d");
+    }
+
+    [Fact]
+    public void Encode_CommaEncodeValuesOnly_HandlesNullEntriesLikeQs()
+    {
+        var options = new EncodeOptions { ListFormat = ListFormat.Comma, EncodeValuesOnly = true };
+
+        Qs.Encode(new Dictionary<string, object?> { ["a"] = new object?[] { null, "b" } }, options)
+            .Should().Be("a=,b");
+
+        Qs.Encode(new Dictionary<string, object?> { ["a"] = new object?[] { null } }, options)
+            .Should().Be("a=");
+
+        Qs.Encode(
+                new Dictionary<string, object?> { ["a"] = new object?[] { null } },
+                options.CopyWith(strictNullHandling: true)
+            )
+            .Should().Be("a");
+
+        Qs.Encode(
+                new Dictionary<string, object?> { ["a"] = new object?[] { null } },
+                options.CopyWith(skipNulls: true)
+            )
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Encode_RoundTripsKeysContainingPercentEncodedBracketText()
+    {
+        var cases = new[]
+        {
+            new Dictionary<string, object?> { ["a%5Bb"] = "c" },
+            new Dictionary<string, object?> { ["a%5Db"] = "c" },
+            new Dictionary<string, object?> { ["a%255Bb"] = "c" },
+            new Dictionary<string, object?> { ["a%255Db"] = "c" },
+            new Dictionary<string, object?> { ["a"] = new Dictionary<string, object?> { ["b%5Bc"] = "d" } },
+            new Dictionary<string, object?> { ["a"] = new Dictionary<string, object?> { ["b%255Bc"] = "d" } },
+            new Dictionary<string, object?> { ["a%5B%255Bb"] = "c" }
+        };
+
+        foreach (var testCase in cases)
+            Qs.Decode(Qs.Encode(testCase)).Should().BeEquivalentTo(testCase);
     }
 
     private sealed class YieldEnumerable : IEnumerable

--- a/QsNet.Tests/EncodeTests.cs
+++ b/QsNet.Tests/EncodeTests.cs
@@ -5912,7 +5912,7 @@ public class EncodeTests
     }
 
     [Fact]
-    public void Encode_StrictNullHandling_FormatsRfc1738BareKey()
+    public void Should_FormatRfc1738BareKeyWhenStrictNullHandling()
     {
         Qs.Encode(
                 new Dictionary<string, object?> { ["a b"] = null },
@@ -5923,7 +5923,7 @@ public class EncodeTests
     }
 
     [Fact]
-    public void Encode_FilterIterable_SkipsNullEntries()
+    public void Should_SkipNullEntriesWhenFilterIterable()
     {
         Qs.Encode(
                 new Dictionary<string, object?>
@@ -5939,7 +5939,7 @@ public class EncodeTests
     }
 
     [Fact]
-    public void Encode_CommaEncodeValuesOnly_HandlesNullEntriesLikeQs()
+    public void Should_HandleNullEntriesLikeQsWhenCommaEncodeValuesOnly()
     {
         var options = new EncodeOptions { ListFormat = ListFormat.Comma, EncodeValuesOnly = true };
 
@@ -5963,7 +5963,7 @@ public class EncodeTests
     }
 
     [Fact]
-    public void Encode_RoundTripsKeysContainingPercentEncodedBracketText()
+    public void Should_RoundTripKeysContainingPercentEncodedBracketText()
     {
         var cases = new[]
         {

--- a/QsNet.Tests/UtilsTests.cs
+++ b/QsNet.Tests/UtilsTests.cs
@@ -1373,7 +1373,7 @@ public class UtilsTests
         var obj = new Dictionary<object, object?> { ["0"] = "a", ["1"] = "b" };
         Utils.IsOverflow(obj).Should().BeFalse();
 
-        var merged = Utils.Merge(obj, "c");
+        var merged = Utils.Merge(obj, "c", new DecodeOptions { StrictMerge = false });
         merged.Should()
             .BeEquivalentTo(
                 new Dictionary<object, object?>
@@ -2159,7 +2159,7 @@ public class UtilsTests
 
         var x = new Dictionary<string, object?> { { "foo", "baz" } };
         Utils
-            .Merge(x, "bar")
+            .Merge(x, "bar", new DecodeOptions { StrictMerge = false })
             .Should()
             .BeEquivalentTo(new Dictionary<string, object?> { { "foo", "baz" }, { "bar", true } });
     }

--- a/QsNet/Internal/Decoder.cs
+++ b/QsNet/Internal/Decoder.cs
@@ -70,7 +70,7 @@ internal static partial class Decoder
                     var end = idx >= 0 ? idx : str.Length;
                     if (enforceListLimit && options.ThrowOnLimitExceeded)
                     {
-                        if (list.Count >= options.ListLimit)
+                        if (currentListLength + list.Count >= options.ListLimit)
                             throw new InvalidOperationException(
                                 $"List limit exceeded. Only {options.ListLimit} element{(options.ListLimit == 1 ? "" : "s")} allowed in a list."
                             );

--- a/QsNet/Internal/Decoder.cs
+++ b/QsNet/Internal/Decoder.cs
@@ -45,14 +45,16 @@ internal static partial class Decoder
     /// <param name="value">The value to parse, which can be a string or any other type.</param>
     /// <param name="options">The decoding options that affect how the value is parsed.</param>
     /// <param name="currentListLength">The current length of the list being parsed, used for limit checks.</param>
+    /// <param name="enforceListLimit">Whether to enforce comma-split list limits for this value.</param>
     /// <returns>The parsed value, which may be a List or the original value if no parsing is needed.</returns>
     private static object? ParseListValue(
         object? value,
         DecodeOptions options,
-        int currentListLength
+        int currentListLength,
+        bool enforceListLimit = true
     )
     {
-        if (options.ListLimit < 0)
+        if (options.ListLimit < 0 && !options.Comma)
             return value;
 
         if (value is string str && options.Comma && str.Length != 0)
@@ -60,39 +62,34 @@ internal static partial class Decoder
             var idx = str.IndexOf(',');
             if (idx >= 0)
             {
-                var remaining = options.ListLimit - currentListLength;
                 var list = new List<object?>();
                 var start = 0;
 
                 while (true)
                 {
                     var end = idx >= 0 ? idx : str.Length;
-                    if (options.ThrowOnLimitExceeded)
+                    if (enforceListLimit && options.ThrowOnLimitExceeded)
                     {
-                        if (currentListLength + list.Count >= options.ListLimit)
+                        if (list.Count >= options.ListLimit)
                             throw new InvalidOperationException(
                                 $"List limit exceeded. Only {options.ListLimit} element{(options.ListLimit == 1 ? "" : "s")} allowed in a list."
                             );
-                        list.Add(str.Substring(start, end - start));
                     }
-                    else
-                    {
-                        if (remaining <= 0)
-                            // Signal ParseQueryStringValues to drop this entire incoming pair (see parsedValue is Undefined -> continue).
-                            return Undefined.Instance;
-                        if (list.Count < remaining)
-                            list.Add(str.Substring(start, end - start));
-                    }
+
+                    list.Add(str.Substring(start, end - start));
 
                     if (idx < 0)
                         break;
 
                     start = idx + 1;
                     idx = str.IndexOf(',', start);
-
-                    if (!options.ThrowOnLimitExceeded && list.Count >= remaining && idx >= 0)
-                        return list;
                 }
+
+                if (
+                    enforceListLimit
+                    && list.Count > options.ListLimit
+                )
+                    return Utils.MarkListOverflow(list);
 
                 return list;
             }
@@ -213,6 +210,7 @@ internal static partial class Decoder
                 break;
             }
 
+            var isBracketArrayKey = pos != -1 && rawKey.EndsWith("[]", StringComparison.Ordinal);
             var hadExisting = obj.TryGetValue(key, out var existingVal);
             if (pos == -1)
             {
@@ -222,7 +220,7 @@ internal static partial class Decoder
             {
                 // Only count existing when combining; Last/First do not increase length.
                 var currentLength = 0;
-                if (hadExisting && options.Duplicates == Duplicates.Combine)
+                if (hadExisting && (options.Duplicates == Duplicates.Combine || isBracketArrayKey))
                 {
                     if (existingVal is IList<object?> l) currentLength = l.Count;
                     else if (!Utils.IsEmpty(existingVal)) currentLength = 1;
@@ -230,9 +228,9 @@ internal static partial class Decoder
 
                 object? parsedValue;
 #if NETSTANDARD2_0
-                parsedValue = ParseListValue(part.Substring(pos + 1), options, currentLength);
+                parsedValue = ParseListValue(part.Substring(pos + 1), options, currentLength, !isBracketArrayKey);
 #else
-                parsedValue = ParseListValue(part[(pos + 1)..], options, currentLength);
+                parsedValue = ParseListValue(part[(pos + 1)..], options, currentLength, !isBracketArrayKey);
 #endif
                 switch (parsedValue)
                 {
@@ -245,6 +243,16 @@ internal static partial class Decoder
                             for (var listIndex = 0; listIndex < parsedList.Count; listIndex++)
                                 decodedList.Add(options.DecodeValue(parsedList[listIndex] as string, charset));
                             value = decodedList;
+                            break;
+                        }
+                    case IDictionary parsedMap:
+                        {
+                            var decodedMap = new Dictionary<object, object?>(parsedMap.Count);
+                            foreach (DictionaryEntry entry in parsedMap)
+                                decodedMap[entry.Key] = options.DecodeValue(entry.Value as string, charset);
+                            if (Utils.IsOverflow(parsedMap))
+                                Utils.MarkOverflow(decodedMap, GetMaxIndex(decodedMap));
+                            value = decodedMap;
                             break;
                         }
                     default:
@@ -266,13 +274,15 @@ internal static partial class Decoder
                 value = Utils.InterpretNumericEntities(tmpStr);
             }
 
-            if (pos != -1 && rawKey.EndsWith("[]", StringComparison.Ordinal))
+            if (isBracketArrayKey)
                 value = value is IEnumerable and not string ? new List<object?> { value } : value;
 
             if (hadExisting)
                 switch (options.Duplicates)
                 {
                     case Duplicates.Combine:
+                    case Duplicates.First when isBracketArrayKey:
+                    case Duplicates.Last when isBracketArrayKey:
                         obj[key] = Utils.CombineWithLimit(existingVal, value, options);
                         break;
                     case Duplicates.Last:
@@ -346,6 +356,16 @@ internal static partial class Decoder
                 count++;
 
         return count;
+    }
+
+    private static int GetMaxIndex(IDictionary map)
+    {
+        var max = -1;
+        foreach (DictionaryEntry entry in map)
+            if (int.TryParse(entry.Key?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var idx)
+                && idx > max)
+                max = idx;
+        return max;
     }
 
     private static List<string> CollectNonEmptyEnumerableParts(IEnumerable<string> parts)
@@ -563,18 +583,25 @@ internal static partial class Decoder
                 else
                     switch (isBracketedNumeric)
                     {
-                        case true when idx >= 0 && idx <= options.ListLimit:
+                        case true when idx >= 0 && idx < options.ListLimit:
                             {
-                                // Build a list up to idx (0 is allowed when ListLimit == 0)
+                                // Build a list up to idx.
                                 var list = new List<object?>(idx + 1);
                                 for (var j = 0; j <= idx; j++)
                                     list.Add(j == idx ? leaf : Undefined.Instance);
                                 obj = list;
                                 break;
                             }
+                        case true when idx >= 0 && options.ThrowOnLimitExceeded:
+                            throw new InvalidOperationException(
+                                $"List limit exceeded. Only {options.ListLimit} element{(options.ListLimit == 1 ? "" : "s")} allowed in a list."
+                            );
                         case true:
                             // Not a list (e.g., idx > ListLimit) → map with the string key (e.g., "2", "99999999")
-                            obj = new Dictionary<object, object?> { [decodedRoot] = leaf };
+                            obj = Utils.MarkOverflow(
+                                new Dictionary<object, object?> { [decodedRoot] = leaf },
+                                idx
+                            );
                             break;
                         default:
                             // Non-numeric or non-bracketed → map with string key

--- a/QsNet/Internal/Utils.cs
+++ b/QsNet/Internal/Utils.cs
@@ -275,7 +275,15 @@ internal static partial class Utils
 
                                         var k = StringifyKey(currentSource);
                                         if (k.Length > 0)
+                                        {
+                                            if (opts.StrictMerge)
+                                            {
+                                                Complete(frame, new List<object?> { mutable, currentSource });
+                                                continue;
+                                            }
+
                                             mutable[k] = true;
+                                        }
 
                                         Complete(frame, mutable);
                                         continue;
@@ -1148,10 +1156,20 @@ internal static partial class Utils
     /// <param name="obj">Object to mark.</param>
     /// <param name="maxIndex">Current maximum index.</param>
     /// <returns>The same object instance for fluent call sites.</returns>
-    private static object MarkOverflow(object obj, int maxIndex)
+    internal static object MarkOverflow(object obj, int maxIndex)
     {
         SetOverflowMaxIndex(obj, maxIndex);
         return obj;
+    }
+
+    /// <summary>
+    ///     Converts a positional list into an overflow-marked dictionary keyed by numeric-string indices.
+    /// </summary>
+    /// <param name="list">List to convert.</param>
+    /// <returns>An overflow dictionary preserving all list values and the highest index.</returns>
+    internal static Dictionary<object, object?> MarkListOverflow(List<object?> list)
+    {
+        return (Dictionary<object, object?>)MarkOverflow(ListToIndexMap(list), list.Count - 1);
     }
 
     /// <summary>
@@ -1231,6 +1249,28 @@ internal static partial class Utils
             target[nextIndex.ToString(CultureInfo.InvariantCulture)] = b;
             SetOverflowMaxIndex(target, nextIndex);
             return target;
+        }
+
+        if (IsOverflow(b) && a is IEnumerable<object?> aEnumerable)
+        {
+            var targetList = aEnumerable as List<object?> ?? CopyToList(aEnumerable);
+            var target = ListToIndexMap(targetList);
+            var nextIndex = targetList.Count - 1;
+            var source = (IDictionary)b!;
+            var numericEntries = new SortedDictionary<int, object?>();
+
+            foreach (DictionaryEntry entry in source)
+            {
+                if (TryGetArrayIndex(entry.Key, out var idx))
+                    numericEntries[idx] = entry.Value;
+                else
+                    target[entry.Key] = entry.Value;
+            }
+
+            foreach (var entry in numericEntries)
+                target[(++nextIndex).ToString(CultureInfo.InvariantCulture)] = entry.Value;
+
+            return MarkOverflow(target, Math.Max(nextIndex, GetOverflowMaxIndex(source)));
         }
 
         var combined = Combine<object?>(a, b);

--- a/QsNet/Internal/Utils.cs
+++ b/QsNet/Internal/Utils.cs
@@ -1251,28 +1251,6 @@ internal static partial class Utils
             return target;
         }
 
-        if (IsOverflow(b) && a is IEnumerable<object?> aEnumerable)
-        {
-            var targetList = aEnumerable as List<object?> ?? CopyToList(aEnumerable);
-            var target = ListToIndexMap(targetList);
-            var nextIndex = targetList.Count - 1;
-            var source = (IDictionary)b!;
-            var numericEntries = new SortedDictionary<int, object?>();
-
-            foreach (DictionaryEntry entry in source)
-            {
-                if (TryGetArrayIndex(entry.Key, out var idx))
-                    numericEntries[idx] = entry.Value;
-                else
-                    target[entry.Key] = entry.Value;
-            }
-
-            foreach (var entry in numericEntries)
-                target[(++nextIndex).ToString(CultureInfo.InvariantCulture)] = entry.Value;
-
-            return MarkOverflow(target, Math.Max(nextIndex, GetOverflowMaxIndex(source)));
-        }
-
         var combined = Combine<object?>(a, b);
         if (combined.Count <= options.ListLimit)
             return combined;

--- a/QsNet/Models/DecodeOptions.cs
+++ b/QsNet/Models/DecodeOptions.cs
@@ -65,8 +65,8 @@ public sealed class DecodeOptions
 
     /// <summary>
     ///     Controls list growth limits during decoding.
-    ///     For explicit numeric indices (for example <c>a[21]</c>), values with index greater than this
-    ///     limit are treated as dictionary entries instead of list entries.
+    ///     For explicit numeric indices (for example <c>a[20]</c>), values with index greater than or
+    ///     equal to this limit are treated as dictionary entries instead of list entries.
     ///     For implicit/comma/combined list growth (for example <c>a[]=1&amp;a[]=2</c>), this is enforced
     ///     as a maximum list size before overflow conversion or exception (when
     ///     <see cref="ThrowOnLimitExceeded" /> is true).
@@ -143,6 +143,13 @@ public sealed class DecodeOptions
     ///     allowing you to catch and handle such cases.
     /// </summary>
     public bool StrictDepth { get; init; }
+
+    /// <summary>
+    ///     Set to true to wrap object/primitive merge conflicts in a list.
+    ///     Set to false to preserve the legacy behavior where non-empty primitive values merge into
+    ///     objects as keys with value true.
+    /// </summary>
+    public bool StrictMerge { get; init; } = true;
 
     /// <summary>
     ///     Set to true to decode values without = to null.
@@ -262,6 +269,7 @@ public sealed class DecodeOptions
     /// <param name="strictDepth">Set to override StrictDepth</param>
     /// <param name="strictNullHandling">Set to override StrictNullHandling</param>
     /// <param name="throwOnLimitExceeded">Set to override ThrowOnLimitExceeded</param>
+    /// <param name="strictMerge">Set to override StrictMerge</param>
     /// <returns>A new DecodeOptions instance with the specified changes</returns>
     public DecodeOptions CopyWith(
         bool? allowDots = null,
@@ -283,7 +291,8 @@ public sealed class DecodeOptions
         bool? parseLists = null,
         bool? strictDepth = null,
         bool? strictNullHandling = null,
-        bool? throwOnLimitExceeded = null
+        bool? throwOnLimitExceeded = null,
+        bool? strictMerge = null
     )
     {
         var finalDecodeDotInKeys = decodeDotInKeys.GetValueOrDefault(DecodeDotInKeys);
@@ -311,6 +320,7 @@ public sealed class DecodeOptions
             InterpretNumericEntities = interpretNumericEntities.GetValueOrDefault(InterpretNumericEntities),
             ParseLists = parseLists.GetValueOrDefault(ParseLists),
             StrictDepth = strictDepth.GetValueOrDefault(StrictDepth),
+            StrictMerge = strictMerge.GetValueOrDefault(StrictMerge),
             StrictNullHandling = strictNullHandling.GetValueOrDefault(StrictNullHandling),
             ThrowOnLimitExceeded = throwOnLimitExceeded.GetValueOrDefault(ThrowOnLimitExceeded)
         };

--- a/QsNet/Qs.cs
+++ b/QsNet/Qs.cs
@@ -251,9 +251,12 @@ public static class Qs
             }
 
             var existing = result[bucketKey];
+            var isBracketArrayKey = decodedKey.EndsWith("[]", StringComparison.Ordinal);
             switch (options.Duplicates)
             {
                 case Duplicates.Combine:
+                case Duplicates.First when isBracketArrayKey:
+                case Duplicates.Last when isBracketArrayKey:
                     result[bucketKey] = Utils.CombineWithLimit(existing, value, options);
                     break;
                 case Duplicates.Last:

--- a/QsNet/Qs.cs
+++ b/QsNet/Qs.cs
@@ -429,7 +429,7 @@ public static class Qs
         {
             if (wroteBodyPart)
                 sb.Append(opts.Delimiter);
-            else if (wroteSentinel) sb.Append('&');
+            else if (wroteSentinel) sb.Append(opts.Delimiter);
 
             sb.Append(part);
             wroteBodyPart = true;

--- a/README.md
+++ b/README.md
@@ -199,6 +199,31 @@ Qs.Decode("foo=bar&foo=baz", new DecodeOptions { Duplicates = Duplicates.Last })
 // => { "foo": "baz" }
 ```
 
+Bracket-array keys always combine, even when plain duplicate keys are configured
+to keep only the first or last value:
+
+```csharp
+Qs.Decode("foo[]=bar&foo[]=baz", new DecodeOptions { Duplicates = Duplicates.First });
+// => { "foo": ["bar", "baz"] }
+```
+
+### Strict merge
+
+Object/primitive merge conflicts wrap into a list by default:
+
+```csharp
+Qs.Decode("a[b]=c&a=d");
+// => { "a": [{ "b": "c" }, "d"] }
+```
+
+Set `StrictMerge` to `false` to preserve the legacy QsNet behavior for
+object-then-primitive conflicts:
+
+```csharp
+Qs.Decode("a[b]=c&a=d", new DecodeOptions { StrictMerge = false });
+// => { "a": { "b": "c", "d": true } }
+```
+
 ### Charset and sentinel
 
 ```csharp
@@ -239,6 +264,12 @@ Qs.Decode("a[1]=b&a[15]=c");
 Qs.Decode("a[]=&a[]=b");
 // => { "a": ["", "b"] }
 ```
+
+`ListLimit` is the maximum element count for lists. Explicit numeric indices are
+list entries only when `index < ListLimit`; an index at or above the limit
+becomes a dictionary entry by default, or throws when `ThrowOnLimitExceeded` is
+true. Implicit list growth, comma lists, and duplicate-combine paths use the same
+element count before overflow conversion or exception.
 
 Large indices convert to a dictionary by default:
 

--- a/docs/docs/decoding.md
+++ b/docs/docs/decoding.md
@@ -98,6 +98,31 @@ Qs.Decode("foo=bar&foo=baz", new DecodeOptions { Duplicates = Duplicates.Last })
 // => { "foo": "baz" }
 ```
 
+Bracket-array keys always combine, even when plain duplicate keys are configured
+to keep only the first or last value:
+
+```csharp
+Qs.Decode("foo[]=bar&foo[]=baz", new DecodeOptions { Duplicates = Duplicates.First });
+// => { "foo": ["bar", "baz"] }
+```
+
+### Strict merge
+
+Object/primitive merge conflicts wrap into a list by default:
+
+```csharp
+Qs.Decode("a[b]=c&a=d");
+// => { "a": [{ "b": "c" }, "d"] }
+```
+
+Set `StrictMerge` to `false` to preserve the legacy QsNet behavior for
+object-then-primitive conflicts:
+
+```csharp
+Qs.Decode("a[b]=c&a=d", new DecodeOptions { StrictMerge = false });
+// => { "a": { "b": "c", "d": true } }
+```
+
 ### Charset and sentinel
 
 ```csharp
@@ -139,9 +164,11 @@ Qs.Decode("a[]=&a[]=b");
 // => { "a": ["", "b"] }
 ```
 
-`ListLimit` uses two related guards:
-- Explicit numeric indices (`a[21]`) are limited by maximum allowed index (`index <= ListLimit`).
-- Implicit/comma/combined list growth (`a[]`, comma lists, duplicate combine paths) is limited by maximum list size before overflow conversion or exception.
+`ListLimit` is the maximum element count for lists. Explicit numeric indices are
+list entries only when `index < ListLimit`; an index at or above the limit
+becomes a dictionary entry by default, or throws when `ThrowOnLimitExceeded` is
+true. Implicit list growth, comma lists, and duplicate-combine paths use the same
+element count before overflow conversion or exception.
 
 Large indices convert to a dictionary by default:
 


### PR DESCRIPTION
This pull request primarily updates the `qs` npm package dependency to version 6.15.2 and significantly expands and refines the test suite for the `QsNet` decoding logic. The test changes focus on stricter and more accurate handling of array/list limits, merging strategies, and edge cases such as comma-separated values and bracket notation. These improvements help ensure the decoder's behavior closely matches the intended and documented behavior, especially in complex or ambiguous scenarios.

**Dependency Update:**
- Upgraded the `qs` npm package from version 6.15.1 to 6.15.2 in both `package.json` and `pnpm-lock.yaml`, ensuring the latest bug fixes and features from the upstream library are included. [[1]](diffhunk://#diff-33714f3b51fe0edf079ff43ee28ff5950d3a22c45469e74c00a1a5fc99698903L9-R9) [[2]](diffhunk://#diff-d7474e380e2258d8c6d903c74bd0919cd41b5c8820608d3d8e2ec8f14a2ff6d3L12-R13) [[3]](diffhunk://#diff-d7474e380e2258d8c6d903c74bd0919cd41b5c8820608d3d8e2ec8f14a2ff6d3L72-R73) [[4]](diffhunk://#diff-d7474e380e2258d8c6d903c74bd0919cd41b5c8820608d3d8e2ec8f14a2ff6d3L150-R150)

**Decode Options and Merge Behavior:**
- Added and tested the `StrictMerge` option in `DecodeOptions`, with new tests verifying both the default and legacy (false) behaviors for merging object and primitive values under the same key. [[1]](diffhunk://#diff-7faa428ecf2b0836aa88101a16f5d62b0b2f122e2b45e843b14435c946424ad4R32) [[2]](diffhunk://#diff-7faa428ecf2b0836aa88101a16f5d62b0b2f122e2b45e843b14435c946424ad4R53) [[3]](diffhunk://#diff-7faa428ecf2b0836aa88101a16f5d62b0b2f122e2b45e843b14435c946424ad4R96) [[4]](diffhunk://#diff-7faa428ecf2b0836aa88101a16f5d62b0b2f122e2b45e843b14435c946424ad4R114) [[5]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdR2667-R2742) [[6]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL4405-R4502)
- Improved handling and tests for duplicate keys, ensuring bracket notation always combines values appropriately regardless of the `Duplicates` setting.

**Array/List Limit Handling:**
- Refined tests to ensure that explicit and implicit array indices respect the `ListLimit` option, including correct conversion to maps when limits are exceeded and proper exception throwing when `ThrowOnLimitExceeded` is set. [[1]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL1185-R1207) [[2]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL1217-R1221) [[3]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL1835-R1844) [[4]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdR2958-R2969) [[5]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL3436-R3555)

**Comma-Separated Value Handling:**
- Overhauled tests for comma-separated values, ensuring that when the sum of values exceeds the list limit, the decoder now converts the result to a map (overflow map) instead of truncating, and all values are preserved. This behavior is now consistently tested across different scenarios, including bracketed keys and nested lists. [[1]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL4650-R4772) [[2]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL4664-R4798) [[3]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL4683-R4824) [[4]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL4702-R4842) [[5]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdR4865-R4880) [[6]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL5391-R5566) [[7]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL5401-R5588) [[8]](diffhunk://#diff-7aebf87dd67b9e97f3a629a859b0aaa0d42c4ba4ed12f41991c943b62241fbcdL5417-R5603)

**Edge Case and Encoding Tests:**
- Added new tests to ensure correct decoding of percent-encoded bracket characters and that literal percent sequences are not incorrectly decoded, improving robustness for unusual but valid inputs.

These changes enhance the reliability and predictability of the decoder, especially in edge cases and under strict option settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added StrictMerge option (defaults to wrapping conflicts); bracket-array keys always combine; refined ListLimit semantics; encoder uses configured delimiter when charset sentinel present.

* **Bug Fixes**
  * Preserve percent-encoded bracket text when decoding; improved comma-list null handling and overflow preservation; stricter list-index/overflow behavior.

* **Tests**
  * Expanded coverage for list limits, comma-split overflow, duplicate/merge behaviors, encoding round-trips.

* **Documentation**
  * Clarified StrictMerge, ListLimit, and bracket-array decoding behavior.

* **Chores**
  * Bumped qs dependency to ^6.15.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techouse/qs-net/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->