### PR TITLE
feat: add `QsNet.Flurl` package with URL helpers for qs-style query strings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           dotnet pack QsNet/QsNet.csproj -c Release -o ./artifacts
           dotnet pack QsNet.AspNetCore/QsNet.AspNetCore.csproj -c Release -o ./artifacts
+          dotnet pack QsNet.Flurl/QsNet.Flurl.csproj -c Release -o ./artifacts
       - name: NuGet login
         uses: NuGet/login@v1
         id: nuget-login
@@ -49,6 +50,7 @@ jobs:
         run: |
           dotnet nuget push ./artifacts/QsNet.$VERSION.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
           dotnet nuget push ./artifacts/QsNet.AspNetCore.$VERSION.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push ./artifacts/QsNet.Flurl.$VERSION.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
       - name: Upload package artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -58,6 +60,8 @@ jobs:
             ./artifacts/QsNet.${{ env.VERSION }}.snupkg
             ./artifacts/QsNet.AspNetCore.${{ env.VERSION }}.nupkg
             ./artifacts/QsNet.AspNetCore.${{ env.VERSION }}.snupkg
+            ./artifacts/QsNet.Flurl.${{ env.VERSION }}.nupkg
+            ./artifacts/QsNet.Flurl.${{ env.VERSION }}.snupkg
           retention-days: 7
   release:
     needs:
@@ -88,6 +92,7 @@ jobs:
           awk '/^##[[:space:]].*/ { if (count == 1) exit; count++; print } count == 1 && !/^##[[:space:]].*/ { print }' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' > $CHANGELOG_PATH
           echo -en "\n[https://www.nuget.org/packages/QsNet](https://www.nuget.org/packages/QsNet)" >> $CHANGELOG_PATH
           echo -en "\n[https://www.nuget.org/packages/QsNet.AspNetCore](https://www.nuget.org/packages/QsNet.AspNetCore)" >> $CHANGELOG_PATH
+          echo -en "\n[https://www.nuget.org/packages/QsNet.Flurl](https://www.nuget.org/packages/QsNet.Flurl)" >> $CHANGELOG_PATH
           echo "CHANGELOG_PATH=$CHANGELOG_PATH" >> $GITHUB_ENV
       - name: Create release
         id: create_release
@@ -101,6 +106,8 @@ jobs:
             ./artifacts/QsNet.${{ env.VERSION }}.snupkg
             ./artifacts/QsNet.AspNetCore.${{ env.VERSION }}.nupkg
             ./artifacts/QsNet.AspNetCore.${{ env.VERSION }}.snupkg
+            ./artifacts/QsNet.Flurl.${{ env.VERSION }}.nupkg
+            ./artifacts/QsNet.Flurl.${{ env.VERSION }}.snupkg
       - name: Clean up
         id: clean_up
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           dotnet pack QsNet/QsNet.csproj -c Release -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=false -p:Version=0.0.0-ci -o $RUNNER_TEMP/nupkg
           dotnet pack QsNet.AspNetCore/QsNet.AspNetCore.csproj -c Release -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=false -p:Version=0.0.0-ci -o $RUNNER_TEMP/nupkg
+          dotnet pack QsNet.Flurl/QsNet.Flurl.csproj -c Release -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=false -p:Version=0.0.0-ci -o $RUNNER_TEMP/nupkg
       - name: Upload nupkg artifact
         uses: actions/upload-artifact@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.1
+
+* [FEAT] add optional `QsNet.Flurl` package targeting `net10.0` / `netstandard2.0` with Flurl URL helpers for appending or replacing qs-style query strings without double-encoding QsNet output
+* [DOCS] document Flurl installation/usage, add DocFX coverage for the Flurl integration package, and update CI/publish flows to include the Flurl package
+
 ## 1.4.0
 
 * [FEAT] add optional `QsNet.AspNetCore` package targeting `net10.0` with `Microsoft.AspNetCore.App` framework reference while keeping the core `QsNet` package framework-agnostic

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,7 @@ Before submitting your PR, please verify:
 3. Ensure `dotnet test` and `dotnet build --configuration Release` pass.
 4. Create a git tag: `git tag v1.x.y`
 5. Push tag: `git push origin v1.x.y`
-6. The `publish.yml` workflow packs and publishes both NuGet packages using NuGet trusted publishing. The repository or environment variable `NUGET_USER` must match the nuget.org profile name for the trusted publishing policy owner.
+6. The `publish.yml` workflow packs and publishes all NuGet packages using NuGet trusted publishing. The repository or environment variable `NUGET_USER` must match the nuget.org profile name for the trusted publishing policy owner.
 7. Create GitHub release with release notes:
    - Added/Changed/Fixed
    - Breaking changes (if any)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <QsNetPackageVersion>1.4.0</QsNetPackageVersion>
+        <QsNetPackageVersion>1.4.1</QsNetPackageVersion>
     </PropertyGroup>
 </Project>

--- a/QsNet.Flurl.Tests/QsNet.Flurl.Tests.csproj
+++ b/QsNet.Flurl.Tests/QsNet.Flurl.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="8.10.0"/>
+        <PackageReference Include="Flurl.Http" Version="4.0.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\QsNet.Flurl\QsNet.Flurl.csproj"/>
+    </ItemGroup>
+</Project>

--- a/QsNet.Flurl.Tests/QsNetFlurlExtensionsTests.cs
+++ b/QsNet.Flurl.Tests/QsNetFlurlExtensionsTests.cs
@@ -37,6 +37,16 @@ public class QsNetFlurlExtensionsTests
     }
 
     [Fact]
+    public void SetQsQueryParams_ShouldClearExistingQueryWhenEncodedQueryIsEmpty()
+    {
+        var result = "https://example.com/search?existing=1".SetQsQueryParams(
+            new Dictionary<string, object?>()
+        );
+
+        result.ToString().Should().Be("https://example.com/search");
+    }
+
+    [Fact]
     public void AppendQsQueryParams_ShouldPreserveFragment()
     {
         var result = "https://example.com/search?existing=1#results".AppendQsQueryParams(
@@ -94,6 +104,17 @@ public class QsNetFlurlExtensionsTests
 
         result.Should().BeSameAs(url);
         result.ToString().Should().Be("https://example.com/search?existing=1#results");
+    }
+
+    [Fact]
+    public void SetQsQueryParams_ShouldReturnSameUrlAndClearExistingQueryWhenEncodedQueryIsEmpty()
+    {
+        var url = new Url("https://example.com/search?existing=1#results");
+
+        var result = url.SetQsQueryParams(new Dictionary<string, object?>());
+
+        result.Should().BeSameAs(url);
+        result.ToString().Should().Be("https://example.com/search#results");
     }
 
     [Fact]

--- a/QsNet.Flurl.Tests/QsNetFlurlExtensionsTests.cs
+++ b/QsNet.Flurl.Tests/QsNetFlurlExtensionsTests.cs
@@ -167,6 +167,16 @@ public class QsNetFlurlExtensionsTests
     }
 
     [Fact]
+    public void SetQsQueryParams_ShouldWorkWithUriOverload()
+    {
+        var uri = new Uri("https://example.com/search?existing=1#results");
+
+        var result = uri.SetQsQueryParams(new { a = "b" });
+
+        result.ToString().Should().Be("https://example.com/search?a=b#results");
+    }
+
+    [Fact]
     public void AppendQsQueryParams_ShouldMutateAndReturnSameUrlInstance()
     {
         var url = new Url("https://example.com/search");

--- a/QsNet.Flurl.Tests/QsNetFlurlExtensionsTests.cs
+++ b/QsNet.Flurl.Tests/QsNetFlurlExtensionsTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Flurl;
+using Flurl.Http;
+using QsNet.Enums;
+using QsNet.Models;
+using Xunit;
+
+namespace QsNet.Flurl.Tests;
+
+public class QsNetFlurlExtensionsTests
+{
+    [Fact]
+    public void AppendQsQueryParams_ShouldAppendToUrlWithoutExistingQuery()
+    {
+        var result = "https://example.com/search".AppendQsQueryParams(new { a = "b" });
+
+        result.ToString().Should().Be("https://example.com/search?a=b");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldAppendToUrlWithExistingQuery()
+    {
+        var result = "https://example.com/search?existing=1".AppendQsQueryParams(new { a = "b" });
+
+        result.ToString().Should().Be("https://example.com/search?existing=1&a=b");
+    }
+
+    [Fact]
+    public void SetQsQueryParams_ShouldReplaceExistingQuery()
+    {
+        var result = "https://example.com/search?existing=1".SetQsQueryParams(new { a = "b" });
+
+        result.ToString().Should().Be("https://example.com/search?a=b");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldPreserveFragment()
+    {
+        var result = "https://example.com/search?existing=1#results".AppendQsQueryParams(
+            new { a = "b" }
+        );
+
+        result.ToString().Should().Be("https://example.com/search?existing=1&a=b#results");
+    }
+
+    [Fact]
+    public void SetQsQueryParams_ShouldPreserveFragment()
+    {
+        var result = "https://example.com/search?existing=1#results".SetQsQueryParams(
+            new { a = "b" }
+        );
+
+        result.ToString().Should().Be("https://example.com/search?a=b#results");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldAppendToUrlEndingWithQuestionMark()
+    {
+        var result = "https://example.com/search?".AppendQsQueryParams(new { a = "b" });
+
+        result.ToString().Should().Be("https://example.com/search?a=b");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldAppendToUrlEndingWithAmpersand()
+    {
+        var result = "https://example.com/search?existing=1&".AppendQsQueryParams(
+            new { a = "b" }
+        );
+
+        result.ToString().Should().Be("https://example.com/search?existing=1&a=b");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldReturnOriginalUrlWhenValuesAreNull()
+    {
+        var url = new Url("https://example.com/search?existing=1#results");
+
+        var result = url.AppendQsQueryParams(null);
+
+        result.Should().BeSameAs(url);
+        result.ToString().Should().Be("https://example.com/search?existing=1#results");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldReturnOriginalUrlWhenEncodedQueryIsEmpty()
+    {
+        var url = new Url("https://example.com/search?existing=1#results");
+
+        var result = url.AppendQsQueryParams(new Dictionary<string, object?>());
+
+        result.Should().BeSameAs(url);
+        result.ToString().Should().Be("https://example.com/search?existing=1#results");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldNotDoubleEncodeNestedBracketNotation()
+    {
+        var result = "https://example.com/search".AppendQsQueryParams(
+            new { foo = new { bar = "baz" } }
+        );
+
+        result.ToString().Should().Be("https://example.com/search?foo%5Bbar%5D=baz");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldEncodeArraysWithQsNetDefaults()
+    {
+        var result = "https://example.com/search".AppendQsQueryParams(
+            new { tags = new[] { "a", "b" } }
+        );
+
+        result.ToString().Should().Be("https://example.com/search?tags%5B0%5D=a&tags%5B1%5D=b");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldWorkWithUrlOverload()
+    {
+        var url = new Url("https://example.com/search");
+
+        var result = url.AppendQsQueryParams(new { a = "b" });
+
+        result.Should().BeSameAs(url);
+        result.ToString().Should().Be("https://example.com/search?a=b");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldWorkWithStringOverload()
+    {
+        var result = "https://example.com/search".AppendQsQueryParams(new { a = "b" });
+
+        result.ToString().Should().Be("https://example.com/search?a=b");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldWorkWithUriOverload()
+    {
+        var uri = new Uri("https://example.com/search#results");
+
+        var result = uri.AppendQsQueryParams(new { a = "b" });
+
+        result.ToString().Should().Be("https://example.com/search?a=b#results");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldMutateAndReturnSameUrlInstance()
+    {
+        var url = new Url("https://example.com/search");
+
+        var result = url.AppendQsQueryParams(new { a = "b" });
+
+        result.Should().BeSameAs(url);
+        url.ToString().Should().Be("https://example.com/search?a=b");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldPassEncodeOptionsThroughAndForceNoQueryPrefix()
+    {
+        var result = "https://example.com/search".AppendQsQueryParams(
+            new { tags = new[] { "a", "b" } },
+            new EncodeOptions(ListFormat.Repeat) { AddQueryPrefix = true }
+        );
+
+        result.ToString().Should().Be("https://example.com/search?tags=a&tags=b");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldSupportFlurlUrlChaining()
+    {
+        var result = "https://api.example.com"
+            .AppendPathSegment("products")
+            .AppendQsQueryParams(new { filter = new { where = new { name = "John" } } })
+            .SetFragment("results");
+
+        result.ToString()
+            .Should()
+            .Be("https://api.example.com/products?filter%5Bwhere%5D%5Bname%5D=John#results");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldSupportFlurlHttpChainingWithoutPackageDependency()
+    {
+        Func<Task<ProductSearchResponse>> requestFactory = () =>
+            "https://api.example.com"
+                .AppendPathSegment("products")
+                .AppendQsQueryParams(new { filter = new { where = new { name = "John" } } })
+                .GetJsonAsync<ProductSearchResponse>();
+
+        requestFactory.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldThrowForCyclicDictionary()
+    {
+        var values = new Dictionary<string, object?>();
+        values["self"] = values;
+
+        var act = () => "https://example.com/search".AppendQsQueryParams(values);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Cyclic object value*");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldThrowForCyclicList()
+    {
+        var values = new List<object?>();
+        values.Add(values);
+
+        var act = () => "https://example.com/search".AppendQsQueryParams(values);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Cyclic object value*");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldThrowForCyclicObject()
+    {
+        var values = new CyclicValue();
+        values.Self = values;
+
+        var act = () => "https://example.com/search".AppendQsQueryParams(values);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Cyclic object value*");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldAllowSharedSiblingReferences()
+    {
+        var shared = new { name = "John" };
+
+        var result = "https://example.com/search".AppendQsQueryParams(
+            new { first = shared, second = shared }
+        );
+
+        result.Query.Should().Contain("first%5Bname%5D=John");
+        result.Query.Should().Contain("second%5Bname%5D=John");
+    }
+
+    private sealed class ProductSearchResponse
+    {
+        public IReadOnlyList<string> Products { get; init; } = Array.Empty<string>();
+    }
+
+    private sealed class CyclicValue
+    {
+        public CyclicValue? Self { get; set; }
+    }
+}

--- a/QsNet.Flurl.Tests/QsNetFlurlExtensionsTests.cs
+++ b/QsNet.Flurl.Tests/QsNetFlurlExtensionsTests.cs
@@ -191,7 +191,7 @@ public class QsNetFlurlExtensionsTests
     public void AppendQsQueryParams_ShouldPassEncodeOptionsThroughAndForceNoQueryPrefix()
     {
         var result = "https://example.com/search".AppendQsQueryParams(
-            new { tags = new[] { "a", "b" } },
+            new { tags = (string[])["a", "b"] },
             new EncodeOptions(ListFormat.Repeat) { AddQueryPrefix = true }
         );
 
@@ -214,11 +214,11 @@ public class QsNetFlurlExtensionsTests
     [Fact]
     public void AppendQsQueryParams_ShouldSupportFlurlHttpChainingWithoutPackageDependency()
     {
-        Func<Task<ProductSearchResponse>> requestFactory = () =>
+        Func<Task<object?>> requestFactory = () =>
             "https://api.example.com"
                 .AppendPathSegment("products")
                 .AppendQsQueryParams(new { filter = new { where = new { name = "John" } } })
-                .GetJsonAsync<ProductSearchResponse>();
+                .GetJsonAsync<object?>();
 
         requestFactory.Should().NotBeNull();
     }
@@ -267,11 +267,6 @@ public class QsNetFlurlExtensionsTests
 
         result.Query.Should().Contain("first%5Bname%5D=John");
         result.Query.Should().Contain("second%5Bname%5D=John");
-    }
-
-    private sealed class ProductSearchResponse
-    {
-        public IReadOnlyList<string> Products { get; init; } = Array.Empty<string>();
     }
 
     private sealed class CyclicValue

--- a/QsNet.Flurl.Tests/QsNetFlurlExtensionsTests.cs
+++ b/QsNet.Flurl.Tests/QsNetFlurlExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -135,6 +136,45 @@ public class QsNetFlurlExtensionsTests
         );
 
         result.ToString().Should().Be("https://example.com/search?tags%5B0%5D=a&tags%5B1%5D=b");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldEncodeStringDictionaryInput()
+    {
+        var values = new Dictionary<string, object?>
+        {
+            ["filter"] = new Dictionary<string, object?> { ["name"] = "John" },
+        };
+
+        var result = "https://example.com/search".AppendQsQueryParams(values);
+
+        result.ToString().Should().Be("https://example.com/search?filter%5Bname%5D=John");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldEncodeNonGenericDictionaryInput()
+    {
+        var values = new Hashtable
+        {
+            ["filter"] = new Hashtable { ["name"] = "John" },
+        };
+
+        var result = "https://example.com/search".AppendQsQueryParams(values);
+
+        result.ToString().Should().Be("https://example.com/search?filter%5Bname%5D=John");
+    }
+
+    [Fact]
+    public void AppendQsQueryParams_ShouldEncodeKeyValuePairSequenceInput()
+    {
+        var values = new List<KeyValuePair<string, object?>>
+        {
+            new("filter", new Dictionary<string, object?> { ["name"] = "John" }),
+        };
+
+        var result = "https://example.com/search".AppendQsQueryParams(values);
+
+        result.ToString().Should().Be("https://example.com/search?filter%5Bname%5D=John");
     }
 
     [Fact]

--- a/QsNet.Flurl/QsNet.Flurl.csproj
+++ b/QsNet.Flurl/QsNet.Flurl.csproj
@@ -1,0 +1,54 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net10.0;netstandard2.0</TargetFrameworks>
+        <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageId>QsNet.Flurl</PackageId>
+        <Version>$(QsNetPackageVersion)</Version>
+        <Authors>Klemen Tusar</Authors>
+        <PackageTags>
+            querystring;query-string;query;parameters;url;uri;http;
+            parser;encoder;encoding;nested;arrays;brackets;
+            qs;flurl;flurl-http
+        </PackageTags>
+        <Description>Flurl URL helpers for QsNet qs-style nested query strings.</Description>
+        <PackageProjectUrl>https://techouse.github.io/qs-net/</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/techouse/qs-net</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+        <EnablePackageValidation>true</EnablePackageValidation>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest-recommended</AnalysisLevel>
+
+        <Deterministic>true</Deterministic>
+        <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+        <TreatWarningsAsErrors Condition="'$(CI)' == 'true'">true</TreatWarningsAsErrors>
+
+        <PackageReleaseNotes>See CHANGELOG: https://github.com/techouse/qs-net/releases</PackageReleaseNotes>
+        <Title>QsNet.Flurl - Flurl helpers for QsNet</Title>
+        <PackageIcon>logo.png</PackageIcon>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\LICENSE" Pack="true" PackagePath="\"/>
+        <None Include="..\logo.png" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\QsNet\QsNet.csproj"/>
+        <PackageReference Include="Flurl" Version="4.0.0"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All"/>
+    </ItemGroup>
+</Project>

--- a/QsNet.Flurl/QsNetFlurlExtensions.cs
+++ b/QsNet.Flurl/QsNetFlurlExtensions.cs
@@ -66,7 +66,10 @@ public static class QsNetFlurlExtensions
 
         var query = EncodeQueryString(values, options);
         if (query.Length == 0)
+        {
+            url.Query = null;
             return url;
+        }
 
         url.Query = query;
         return url;

--- a/QsNet.Flurl/QsNetFlurlExtensions.cs
+++ b/QsNet.Flurl/QsNetFlurlExtensions.cs
@@ -173,8 +173,7 @@ public static class QsNetFlurlExtensions
                 IDictionary<string, object?> stringDictionary => ConvertStringDictionary(stringDictionary, activePath),
                 IDictionary dictionary => ConvertDictionary(dictionary, activePath),
                 IEnumerable<KeyValuePair<string, object?>> pairs => ConvertPairs(pairs, activePath),
-                IEnumerable enumerable and not string and not byte[] => ConvertEnumerable(enumerable,
-                    activePath),
+                IEnumerable enumerable and not string and not byte[] => ConvertEnumerable(enumerable, activePath),
                 _ => ConvertObject(value, activePath)
             };
         }

--- a/QsNet.Flurl/QsNetFlurlExtensions.cs
+++ b/QsNet.Flurl/QsNetFlurlExtensions.cs
@@ -217,9 +217,6 @@ public static class QsNetFlurlExtensions
         var result = new Dictionary<string, object?>(dictionary.Count);
         foreach (DictionaryEntry entry in dictionary)
         {
-            if (entry.Key is null)
-                continue;
-
             var key = Convert.ToString(entry.Key, CultureInfo.InvariantCulture);
             if (key is null)
                 continue;

--- a/QsNet.Flurl/QsNetFlurlExtensions.cs
+++ b/QsNet.Flurl/QsNetFlurlExtensions.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Flurl;
+using QsNet.Models;
+
+namespace QsNet.Flurl;
+
+/// <summary>
+///     Flurl-friendly helpers for adding qs-style nested query strings to URLs.
+/// </summary>
+public static class QsNetFlurlExtensions
+{
+    /// <summary>
+    ///     Appends a qs-style query string generated from <paramref name="values" /> to a Flurl URL.
+    /// </summary>
+    /// <param name="url">The Flurl URL to mutate.</param>
+    /// <param name="values">The object, dictionary, or sequence to encode.</param>
+    /// <param name="options">Optional QsNet encoder settings.</param>
+    /// <returns>The same Flurl URL instance with the encoded query string appended.</returns>
+    public static Url AppendQsQueryParams(
+        this Url url,
+        object? values,
+        EncodeOptions? options = null
+    )
+    {
+        ThrowIfNull(url, nameof(url));
+
+        if (values is null)
+            return url;
+
+        var query = EncodeQueryString(values, options);
+        if (query.Length == 0)
+            return url;
+
+        var existingQuery = url.Query;
+        url.Query = string.IsNullOrEmpty(existingQuery)
+            ? query
+            : existingQuery[existingQuery.Length - 1] == '&'
+                ? string.Concat(existingQuery, query)
+                : string.Concat(existingQuery, "&", query);
+
+        return url;
+    }
+
+    /// <summary>
+    ///     Replaces a Flurl URL query string with a qs-style query string generated from <paramref name="values" />.
+    /// </summary>
+    /// <param name="url">The Flurl URL to mutate.</param>
+    /// <param name="values">The object, dictionary, or sequence to encode.</param>
+    /// <param name="options">Optional QsNet encoder settings.</param>
+    /// <returns>The same Flurl URL instance with the encoded query string set.</returns>
+    public static Url SetQsQueryParams(
+        this Url url,
+        object? values,
+        EncodeOptions? options = null
+    )
+    {
+        ThrowIfNull(url, nameof(url));
+
+        if (values is null)
+            return url;
+
+        var query = EncodeQueryString(values, options);
+        if (query.Length == 0)
+            return url;
+
+        url.Query = query;
+        return url;
+    }
+
+    /// <summary>
+    ///     Creates a Flurl URL and appends a qs-style query string generated from <paramref name="values" />.
+    /// </summary>
+    /// <param name="url">The URL string to append to.</param>
+    /// <param name="values">The object, dictionary, or sequence to encode.</param>
+    /// <param name="options">Optional QsNet encoder settings.</param>
+    /// <returns>A Flurl URL with the encoded query string appended.</returns>
+    public static Url AppendQsQueryParams(
+        this string url,
+        object? values,
+        EncodeOptions? options = null
+    )
+    {
+        ThrowIfNull(url, nameof(url));
+
+        return new Url(url).AppendQsQueryParams(values, options);
+    }
+
+    /// <summary>
+    ///     Creates a Flurl URL and replaces its query string with one generated from <paramref name="values" />.
+    /// </summary>
+    /// <param name="url">The URL string to update.</param>
+    /// <param name="values">The object, dictionary, or sequence to encode.</param>
+    /// <param name="options">Optional QsNet encoder settings.</param>
+    /// <returns>A Flurl URL with the encoded query string set.</returns>
+    public static Url SetQsQueryParams(
+        this string url,
+        object? values,
+        EncodeOptions? options = null
+    )
+    {
+        ThrowIfNull(url, nameof(url));
+
+        return new Url(url).SetQsQueryParams(values, options);
+    }
+
+    /// <summary>
+    ///     Creates a Flurl URL from a URI and appends a qs-style query string generated from <paramref name="values" />.
+    /// </summary>
+    /// <param name="uri">The URI to append to.</param>
+    /// <param name="values">The object, dictionary, or sequence to encode.</param>
+    /// <param name="options">Optional QsNet encoder settings.</param>
+    /// <returns>A Flurl URL with the encoded query string appended.</returns>
+    public static Url AppendQsQueryParams(
+        this Uri uri,
+        object? values,
+        EncodeOptions? options = null
+    )
+    {
+        ThrowIfNull(uri, nameof(uri));
+
+        return new Url(uri).AppendQsQueryParams(values, options);
+    }
+
+    /// <summary>
+    ///     Creates a Flurl URL from a URI and replaces its query string with one generated from <paramref name="values" />.
+    /// </summary>
+    /// <param name="uri">The URI to update.</param>
+    /// <param name="values">The object, dictionary, or sequence to encode.</param>
+    /// <param name="options">Optional QsNet encoder settings.</param>
+    /// <returns>A Flurl URL with the encoded query string set.</returns>
+    public static Url SetQsQueryParams(
+        this Uri uri,
+        object? values,
+        EncodeOptions? options = null
+    )
+    {
+        ThrowIfNull(uri, nameof(uri));
+
+        return new Url(uri).SetQsQueryParams(values, options);
+    }
+
+    private static string EncodeQueryString(object values, EncodeOptions? options)
+    {
+        var normalized = NormalizeValue(values);
+        var encodeOptions = options?.CopyWith(addQueryPrefix: false) ?? new EncodeOptions();
+
+        return Qs.Encode(normalized, encodeOptions);
+    }
+
+    private static object? NormalizeValue(object? value) =>
+        NormalizeValue(value, new HashSet<object>(ReferenceEqualityComparer.Instance));
+
+    private static object? NormalizeValue(object? value, HashSet<object> activePath)
+    {
+        if (value is null || IsScalar(value))
+            return value;
+
+        if (!activePath.Add(value))
+            throw new InvalidOperationException("Cyclic object value");
+
+        try
+        {
+            if (value is IDictionary<string, object?> stringDictionary)
+                return ConvertStringDictionary(stringDictionary, activePath);
+
+            if (value is IDictionary dictionary)
+                return ConvertDictionary(dictionary, activePath);
+
+            if (value is IEnumerable<KeyValuePair<string, object?>> pairs)
+                return ConvertPairs(pairs, activePath);
+
+            if (value is IEnumerable enumerable && value is not string and not byte[])
+                return ConvertEnumerable(enumerable, activePath);
+
+            return ConvertObject(value, activePath);
+        }
+        finally
+        {
+            activePath.Remove(value);
+        }
+    }
+
+    private static Dictionary<string, object?> ConvertStringDictionary(
+        IDictionary<string, object?> dictionary,
+        HashSet<object> activePath
+    )
+    {
+        var result = new Dictionary<string, object?>(dictionary.Count);
+        foreach (var pair in dictionary)
+            result[pair.Key] = NormalizeValue(pair.Value, activePath);
+
+        return result;
+    }
+
+    private static Dictionary<string, object?> ConvertPairs(
+        IEnumerable<KeyValuePair<string, object?>> pairs,
+        HashSet<object> activePath
+    )
+    {
+        var result = new Dictionary<string, object?>();
+        foreach (var pair in pairs)
+            result[pair.Key] = NormalizeValue(pair.Value, activePath);
+
+        return result;
+    }
+
+    private static Dictionary<string, object?> ConvertDictionary(
+        IDictionary dictionary,
+        HashSet<object> activePath
+    )
+    {
+        var result = new Dictionary<string, object?>(dictionary.Count);
+        foreach (DictionaryEntry entry in dictionary)
+        {
+            if (entry.Key is null)
+                continue;
+
+            var key = Convert.ToString(entry.Key, CultureInfo.InvariantCulture);
+            if (key is null)
+                continue;
+
+            result[key] = NormalizeValue(entry.Value, activePath);
+        }
+
+        return result;
+    }
+
+    private static List<object?> ConvertEnumerable(IEnumerable enumerable, HashSet<object> activePath)
+    {
+        var result = new List<object?>();
+        foreach (var item in enumerable)
+            result.Add(NormalizeValue(item, activePath));
+
+        return result;
+    }
+
+    private static Dictionary<string, object?> ConvertObject(
+        object value,
+        HashSet<object> activePath
+    )
+    {
+        var properties = value.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);
+        var result = new Dictionary<string, object?>(properties.Length);
+
+        foreach (var property in properties)
+        {
+            if (property.GetIndexParameters().Length != 0)
+                continue;
+
+            var getter = property.GetGetMethod(false);
+            if (getter is null)
+                continue;
+
+            result[property.Name] = NormalizeValue(property.GetValue(value, null), activePath);
+        }
+
+        return result;
+    }
+
+    private static bool IsScalar(object value)
+    {
+        if (value is string or byte[] or Uri)
+            return true;
+
+        var type = Nullable.GetUnderlyingType(value.GetType()) ?? value.GetType();
+
+        return type.IsPrimitive
+               || type.IsEnum
+               || type == typeof(decimal)
+               || type == typeof(DateTime)
+               || type == typeof(DateTimeOffset)
+               || type == typeof(Guid);
+    }
+
+    private static void ThrowIfNull(object? argument, string paramName)
+    {
+#if NETSTANDARD2_0
+        if (argument is null)
+            throw new ArgumentNullException(paramName);
+#else
+        ArgumentNullException.ThrowIfNull(argument, paramName);
+#endif
+    }
+
+    private sealed class ReferenceEqualityComparer : IEqualityComparer<object>
+    {
+        public static readonly ReferenceEqualityComparer Instance = new();
+
+        private ReferenceEqualityComparer()
+        {
+        }
+
+        public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
+    }
+}

--- a/QsNet.Flurl/QsNetFlurlExtensions.cs
+++ b/QsNet.Flurl/QsNetFlurlExtensions.cs
@@ -1,6 +1,8 @@
+#if NETSTANDARD2_0
 using System;
-using System.Collections;
 using System.Collections.Generic;
+#endif
+using System.Collections;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/QsNet.Flurl/QsNetFlurlExtensions.cs
+++ b/QsNet.Flurl/QsNetFlurlExtensions.cs
@@ -236,10 +236,7 @@ public static class QsNetFlurlExtensions
         return result;
     }
 
-    private static Dictionary<string, object?> ConvertObject(
-        object value,
-        HashSet<object> activePath
-    )
+    private static Dictionary<string, object?> ConvertObject(object value, HashSet<object> activePath)
     {
         var properties = value.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);
         var result = new Dictionary<string, object?>(properties.Length);

--- a/QsNet.Flurl/QsNetFlurlExtensions.cs
+++ b/QsNet.Flurl/QsNetFlurlExtensions.cs
@@ -168,19 +168,15 @@ public static class QsNetFlurlExtensions
 
         try
         {
-            if (value is IDictionary<string, object?> stringDictionary)
-                return ConvertStringDictionary(stringDictionary, activePath);
-
-            if (value is IDictionary dictionary)
-                return ConvertDictionary(dictionary, activePath);
-
-            if (value is IEnumerable<KeyValuePair<string, object?>> pairs)
-                return ConvertPairs(pairs, activePath);
-
-            if (value is IEnumerable enumerable && value is not string and not byte[])
-                return ConvertEnumerable(enumerable, activePath);
-
-            return ConvertObject(value, activePath);
+            return value switch
+            {
+                IDictionary<string, object?> stringDictionary => ConvertStringDictionary(stringDictionary, activePath),
+                IDictionary dictionary => ConvertDictionary(dictionary, activePath),
+                IEnumerable<KeyValuePair<string, object?>> pairs => ConvertPairs(pairs, activePath),
+                IEnumerable enumerable and not string and not byte[] => ConvertEnumerable(enumerable,
+                    activePath),
+                _ => ConvertObject(value, activePath)
+            };
         }
         finally
         {
@@ -255,8 +251,7 @@ public static class QsNetFlurlExtensions
             if (property.GetIndexParameters().Length != 0)
                 continue;
 
-            var getter = property.GetGetMethod(false);
-            if (getter is null)
+            if (property.GetGetMethod(false) is null)
                 continue;
 
             result[property.Name] = NormalizeValue(property.GetValue(value, null), activePath);
@@ -298,7 +293,7 @@ public static class QsNetFlurlExtensions
         {
         }
 
-        public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+        bool IEqualityComparer<object>.Equals(object? x, object? y) => ReferenceEquals(x, y);
 
         public int GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
     }

--- a/QsNet.Flurl/QsNetFlurlExtensions.cs
+++ b/QsNet.Flurl/QsNetFlurlExtensions.cs
@@ -37,11 +37,13 @@ public static class QsNetFlurlExtensions
             return url;
 
         var existingQuery = url.Query;
-        url.Query = string.IsNullOrEmpty(existingQuery)
-            ? query
-            : existingQuery[existingQuery.Length - 1] == '&'
-                ? string.Concat(existingQuery, query)
-                : string.Concat(existingQuery, "&", query);
+
+        if (string.IsNullOrEmpty(existingQuery))
+            url.Query = query;
+        else if (existingQuery[existingQuery.Length - 1] == '&')
+            url.Query = string.Concat(existingQuery, query);
+        else
+            url.Query = string.Concat(existingQuery, "&", query);
 
         return url;
     }

--- a/QsNet.sln
+++ b/QsNet.sln
@@ -11,6 +11,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QsNet.AspNetCore", "QsNet.A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QsNet.AspNetCore.Tests", "QsNet.AspNetCore.Tests\QsNet.AspNetCore.Tests.csproj", "{B2A8590B-532B-40E0-9D6D-8D5E07C931F6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QsNet.Flurl", "QsNet.Flurl\QsNet.Flurl.csproj", "{AE24D6EE-4F41-4BCC-A7AF-952A535B8EC3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QsNet.Flurl.Tests", "QsNet.Flurl.Tests\QsNet.Flurl.Tests.csproj", "{75C93610-FB96-4B83-A05C-B6987F66B8FF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,5 +41,13 @@ Global
 		{B2A8590B-532B-40E0-9D6D-8D5E07C931F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B2A8590B-532B-40E0-9D6D-8D5E07C931F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B2A8590B-532B-40E0-9D6D-8D5E07C931F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE24D6EE-4F41-4BCC-A7AF-952A535B8EC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE24D6EE-4F41-4BCC-A7AF-952A535B8EC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE24D6EE-4F41-4BCC-A7AF-952A535B8EC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE24D6EE-4F41-4BCC-A7AF-952A535B8EC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75C93610-FB96-4B83-A05C-B6987F66B8FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75C93610-FB96-4B83-A05C-B6987F66B8FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75C93610-FB96-4B83-A05C-B6987F66B8FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75C93610-FB96-4B83-A05C-B6987F66B8FF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ dotnet add package QsNet.AspNetCore
 <PackageReference Include="QsNet.AspNetCore" Version="<version>"/>
 ```
 
+### Flurl integration
+
+Install the optional Flurl helper package in applications that build URLs with
+Flurl:
+
+```bash
+dotnet add package QsNet.Flurl
+```
+
+```xml
+<PackageReference Include="QsNet.Flurl" Version="<version>"/>
+```
+
 ---
 
 ## Requirements
@@ -120,6 +133,26 @@ Dictionary<string, object?> query = httpContext.Request.ToQueryMap();
 `QsNet.AspNetCore` appends the already encoded QsNet output directly, preserving
 fragments and bracket notation without re-encoding through ASP.NET Core
 `QueryHelpers`.
+
+### Flurl helpers
+
+```csharp
+using Flurl;
+using QsNet.Flurl;
+
+var url = "https://api.example.com"
+    .AppendPathSegment("products")
+    .AppendQsQueryParams(new
+    {
+        filter = new { name = "Alice" },
+        tags = new[] { "one", "two" },
+    });
+// -> "https://api.example.com/products?filter%5Bname%5D=Alice&tags%5B0%5D=one&tags%5B1%5D=two"
+```
+
+`QsNet.Flurl` writes QsNet's already encoded output through Flurl's `Url.Query`
+instead of Flurl's normal query-parameter APIs, avoiding double-encoding of
+qs-style bracket notation.
 
 ---
 

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -8,6 +8,7 @@
           <!-- source-only coverage for QsNet assemblies -->
           <Include>[QsNet]QsNet.*</Include>
           <Include>[QsNet.AspNetCore]QsNet.AspNetCore.*</Include>
+          <Include>[QsNet.Flurl]QsNet.Flurl.*</Include>
           <IncludeTestAssembly>false</IncludeTestAssembly>
           <!-- exclude designer/auto-generated -->
           <ExcludeByFile>**/*Designer.cs;**/*Generated*.cs;**/obj/**/RegexGenerator.g.cs</ExcludeByFile>

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -7,11 +7,13 @@
           "src": "..",
           "files": [
             "QsNet/QsNet.csproj",
-            "QsNet.AspNetCore/QsNet.AspNetCore.csproj"
+            "QsNet.AspNetCore/QsNet.AspNetCore.csproj",
+            "QsNet.Flurl/QsNet.Flurl.csproj"
           ],
           "exclude": [
             "**/QsNet.Tests/**",
-            "**/QsNet.AspNetCore.Tests/**"
+            "**/QsNet.AspNetCore.Tests/**",
+            "**/QsNet.Flurl.Tests/**"
           ]
         }
       ],

--- a/docs/docs/flurl.md
+++ b/docs/docs/flurl.md
@@ -1,0 +1,67 @@
+## Flurl
+
+`QsNet.Flurl` provides thin helpers for adding QsNet-generated nested query
+strings to Flurl URLs. The core `QsNet` package stays Flurl-free; install this
+package only where Flurl URL builders are useful.
+
+```bash
+dotnet add package QsNet.Flurl
+```
+
+### Append qs-style query strings
+
+```csharp
+using Flurl;
+using QsNet.Flurl;
+
+var url = "https://api.example.com"
+    .AppendPathSegment("products")
+    .AppendQsQueryParams(new
+    {
+        filter = new
+        {
+            where = new
+            {
+                name = "John",
+                age = new { gte = 30 },
+            },
+        },
+        tags = new[] { "a", "b" },
+    });
+
+// "https://api.example.com/products?filter%5Bwhere%5D%5Bname%5D=John&filter%5Bwhere%5D%5Bage%5D%5Bgte%5D=30&tags%5B0%5D=a&tags%5B1%5D=b"
+```
+
+`AppendQsQueryParams` appends QsNet's already encoded output directly to the
+Flurl `Url.Query`. It does not pass the complete qs-style string through Flurl's
+normal query-parameter APIs, so encoded bracket notation is not double-encoded.
+
+### Replace query strings
+
+```csharp
+using QsNet.Flurl;
+
+var url = "https://api.example.com/products?existing=1#results"
+    .SetQsQueryParams(new { filter = new { name = "John" } });
+
+// "https://api.example.com/products?filter%5Bname%5D=John#results"
+```
+
+### Flurl.Http chaining
+
+```csharp
+using Flurl;
+using Flurl.Http;
+using QsNet.Flurl;
+
+var response = await "https://api.example.com"
+    .AppendPathSegment("products")
+    .AppendQsQueryParams(new
+    {
+        filter = new
+        {
+            where = new { name = "John" },
+        },
+    })
+    .GetJsonAsync<ProductSearchResponse>();
+```

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -31,9 +31,23 @@ dotnet add package QsNet.AspNetCore
 <PackageReference Include="QsNet.AspNetCore" Version="<version>" />
 ```
 
+## Flurl integration
+
+For applications using Flurl URL builders, install the optional integration
+package:
+
+```bash
+dotnet add package QsNet.Flurl
+```
+
+```xml
+<PackageReference Include="QsNet.Flurl" Version="<version>" />
+```
+
 ---
 
 ## Requirements
 
 - `QsNet`: `net10.0`, `netstandard2.0`
 - `QsNet.AspNetCore`: `net10.0`
+- `QsNet.Flurl`: `net10.0`, `netstandard2.0`

--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -6,3 +6,5 @@
   href: encoding.md
 - name: ASP.NET Core
   href: aspnet-core.md
+- name: Flurl
+  href: flurl.md


### PR DESCRIPTION
This pull request introduces the new `QsNet.Flurl` package, which provides Flurl URL helpers for working with qs-style query strings using QsNet. The release targets both `net10.0` and `netstandard2.0`, and includes comprehensive documentation, test coverage, and CI/CD integration. The changelog and project version have been updated accordingly.

**New Package: QsNet.Flurl**

* Added new `QsNet.Flurl` package targeting `net10.0` and `netstandard2.0`, providing Flurl URL helpers for appending or replacing qs-style query strings without double-encoding QsNet output. Includes project file, metadata, and packaging details.
* Added comprehensive unit tests for `QsNet.Flurl` extension methods in `QsNet.Flurl.Tests`, covering various use cases and edge cases. [[1]](diffhunk://#diff-aeafeea17556949d9beae52a8972adba3f8123821d6efe3447ec6d7146d7bf80R1-R250) [[2]](diffhunk://#diff-124333ba1c126658d7712044cdae6f3b20b89cd21f493e5bf0f9b573b5fdc4d5R1-R24)

**Documentation and Changelog**

* Updated `CHANGELOG.md` with a new 1.4.1 entry describing the addition of `QsNet.Flurl`, documentation, and CI/publish flow updates.
* Documented Flurl installation/usage and added DocFX coverage for the integration package.

**CI/CD Integration**

* Updated GitHub Actions workflows (`publish.yml`, `test.yml`) to build, test, pack, and publish the new `QsNet.Flurl` package alongside existing packages. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R41) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R53) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R63-R64) [[4]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R95) [[5]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R109-R110) [[6]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R47)
* Clarified in `CONTRIBUTING.md` that the publish workflow now packs and publishes all NuGet packages.

**Versioning**

* Bumped the package version to 1.4.1 in `Directory.Build.props`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional QsNet.Flurl package (v1.4.1) with Flurl extension methods to append/replace qs-style query parameters without double-encoding.

* **Documentation**
  * Added Flurl integration docs, install instructions, examples, README updates, TOC and installation pages; added API docs entry.

* **Tests**
  * Added comprehensive tests covering append/set behavior, encoding, fragments, overloads, chaining, cycle detection and coverage.

* **Chores**
  * Bumped package version, updated CI/publish flows to pack/publish the Flurl package and include its artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->