### PR TITLE
feat: add `DecodeQsQuery` extension for `System.Uri`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,6 +199,16 @@ jobs:
                       });
                       if (string.IsNullOrEmpty(qs))
                           throw new Exception("Encode returned empty string");
+                      var absoluteQuery = new Uri(
+                          "https://example.com/search?a%5Bb%5D=x%26y#fragment"
+                      ).DecodeQsQuery();
+                      var absoluteNested = (Dictionary<string, object?>)absoluteQuery["a"]!;
+                      if (!object.Equals(absoluteNested["b"], "x&y"))
+                          throw new Exception("Absolute URI query decode failed");
+                      var relativeQuery = new Uri("?value=a+b#fragment", UriKind.Relative)
+                          .DecodeQsQuery();
+                      if (!object.Equals(relativeQuery["value"], "a b"))
+                          throw new Exception("Relative URI query decode failed");
                       Console.WriteLine("SMOKE OK");
                       return 0;
                   }
@@ -294,6 +304,9 @@ jobs:
                   var qs = Qs.Encode(new Dictionary<string, object?> {
                       ["a"] = new Dictionary<string, object?> { ["b"] = "c" }
                   });
+                  var uriQuery = new Uri(
+                      "https://example.com/search?a%5Bb%5D=x%26y#fragment"
+                  ).DecodeQsQuery();
                   return string.IsNullOrEmpty(qs) ? 1 : 0;
               }
           }
@@ -349,6 +362,16 @@ jobs:
                       });
                       if (string.IsNullOrEmpty(qs))
                           throw new Exception("Encode returned empty string");
+                      var absoluteQuery = new Uri(
+                          "https://example.com/search?a%5Bb%5D=x%26y#fragment"
+                      ).DecodeQsQuery();
+                      var absoluteNested = (Dictionary<string, object?>)absoluteQuery["a"]!;
+                      if (!object.Equals(absoluteNested["b"], "x&y"))
+                          throw new Exception("Absolute URI query decode failed");
+                      var relativeQuery = new Uri("?value=a+b#fragment", UriKind.Relative)
+                          .DecodeQsQuery();
+                      if (!object.Equals(relativeQuery["value"], "a b"))
+                          throw new Exception("Relative URI query decode failed");
           #if NET461
                       Console.WriteLine("SMOKE net461 OK");
           #elif NET481

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.4-dev
+
+* [FEAT] add a read-only `DecodeQsQuery` extension for `System.Uri` that decodes escaped query components from absolute and relative URIs while excluding fragments and preserving QsNet decoder options
+
 ## 1.4.3
 
 * [FEAT] add optional `QsNet.RestSharp` package targeting `net10.0` / `netstandard2.0` with append-only RestSharp request helpers for qs-style nested query parameters

--- a/QsNet.Tests/UriExtensionTests.cs
+++ b/QsNet.Tests/UriExtensionTests.cs
@@ -9,7 +9,7 @@ namespace QsNet.Tests;
 public class UriExtensionTests
 {
     [Fact]
-    public void DecodeQsQuery_ShouldPreserveEscapedQuerySyntaxUntilQsDecode()
+    public void ShouldPreserveEscapedQuerySyntaxUntilQsDecode()
     {
         var uri = new Uri(
             "https://example.com/search?" +
@@ -41,7 +41,7 @@ public class UriExtensionTests
     [InlineData("a=x&a=y")]
     [InlineData("items%5B0%5D%5Bid%5D=1&items%5B1%5D%5Bid%5D=2")]
     [InlineData("first=1&a=x&middle=2&a=y")]
-    public void DecodeQsQuery_ShouldMatchQsDecodeForStructuredAndDuplicatePairs(string query)
+    public void ShouldMatchQsDecodeForStructuredAndDuplicatePairs(string query)
     {
         var uri = new Uri($"https://example.com/search?{query}#results");
 
@@ -51,7 +51,7 @@ public class UriExtensionTests
     }
 
     [Fact]
-    public void DecodeQsQuery_ShouldPassDecodeOptionsThrough()
+    public void ShouldPassDecodeOptionsThrough()
     {
         var uri = new Uri("https://example.com/search?values=one,two,three");
 
@@ -64,7 +64,7 @@ public class UriExtensionTests
     }
 
     [Fact]
-    public void DecodeQsQuery_ShouldDistinguishNameOnlyAndEmptyValues()
+    public void ShouldDistinguishNameOnlyAndEmptyValues()
     {
         var uri = new Uri("https://example.com/search?flag&empty=#results");
 
@@ -78,7 +78,7 @@ public class UriExtensionTests
     }
 
     [Fact]
-    public void DecodeQsQuery_ShouldRespectCustomDelimiter()
+    public void ShouldRespectCustomDelimiter()
     {
         var uri = new Uri("https://example.com/search?a=b;c=d#results");
 
@@ -98,7 +98,7 @@ public class UriExtensionTests
     [InlineData("https://example.com/search?")]
     [InlineData("https://example.com/search?#results")]
     [InlineData("https://example.com/search#results")]
-    public void DecodeQsQuery_ShouldReturnEmptyMapForAbsentOrEmptyAbsoluteQuery(string value)
+    public void ShouldReturnEmptyMapForAbsentOrEmptyAbsoluteQuery(string value)
     {
         var uri = new Uri(value);
 
@@ -114,7 +114,7 @@ public class UriExtensionTests
     [InlineData("search?#frag", "")]
     [InlineData("search", "")]
     [InlineData("#frag?not=query", "")]
-    public void DecodeQsQuery_ShouldExtractRelativeQueryWithoutFragment(
+    public void ShouldExtractRelativeQueryWithoutFragment(
         string value,
         string query
     )
@@ -127,7 +127,7 @@ public class UriExtensionTests
     }
 
     [Fact]
-    public void DecodeQsQuery_ShouldDecodeOpaqueAbsoluteUriQuery()
+    public void ShouldDecodeOpaqueAbsoluteUriQuery()
     {
         var uri = new Uri("mailto:user@example.com?subject=a%26b#frag");
 
@@ -140,7 +140,7 @@ public class UriExtensionTests
     }
 
     [Fact]
-    public void DecodeQsQuery_ShouldUseUriCanonicalizationForMalformedEscapes()
+    public void ShouldUseUriCanonicalizationForMalformedEscapes()
     {
         var uri = new Uri("https://example.com/search?bad=%ZZ&tail=%");
 
@@ -154,7 +154,7 @@ public class UriExtensionTests
     }
 
     [Fact]
-    public void DecodeQsQuery_ShouldThrowForNullUri()
+    public void ShouldThrowForNullUri()
     {
         Uri? uri = null;
 

--- a/QsNet.Tests/UriExtensionTests.cs
+++ b/QsNet.Tests/UriExtensionTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using QsNet.Models;
+using Xunit;
+
+namespace QsNet.Tests;
+
+public class UriExtensionTests
+{
+    [Fact]
+    public void DecodeQsQuery_ShouldPreserveEscapedQuerySyntaxUntilQsDecode()
+    {
+        var uri = new Uri(
+            "https://example.com/search?" +
+            "filter%5Bwhere%5D%5Bname%5D=John%20Doe&" +
+            "tag=a&tag=b&" +
+            "escaped=x%26y&" +
+            "pct=%2525&" +
+            "plus=a+b#results"
+        );
+
+        var result = uri.DecodeQsQuery();
+
+        result.Should().BeEquivalentTo(new Dictionary<string, object?>
+        {
+            ["filter"] = new Dictionary<string, object?>
+            {
+                ["where"] = new Dictionary<string, object?> { ["name"] = "John Doe" }
+            },
+            ["tag"] = new List<object?> { "a", "b" },
+            ["escaped"] = "x&y",
+            ["pct"] = "%25",
+            ["plus"] = "a b"
+        });
+    }
+
+    [Theory]
+    [InlineData("a%5B0%5D=x&a%5B1%5D=y")]
+    [InlineData("a%5B%5D=x&a%5B%5D=y")]
+    [InlineData("a=x&a=y")]
+    [InlineData("items%5B0%5D%5Bid%5D=1&items%5B1%5D%5Bid%5D=2")]
+    [InlineData("first=1&a=x&middle=2&a=y")]
+    public void DecodeQsQuery_ShouldMatchQsDecodeForStructuredAndDuplicatePairs(string query)
+    {
+        var uri = new Uri($"https://example.com/search?{query}#results");
+
+        var result = uri.DecodeQsQuery();
+
+        result.Should().BeEquivalentTo(Qs.Decode(query));
+    }
+
+    [Fact]
+    public void DecodeQsQuery_ShouldPassDecodeOptionsThrough()
+    {
+        var uri = new Uri("https://example.com/search?values=one,two,three");
+
+        var result = uri.DecodeQsQuery(new DecodeOptions { Comma = true });
+
+        result.Should().BeEquivalentTo(new Dictionary<string, object?>
+        {
+            ["values"] = new List<object?> { "one", "two", "three" }
+        });
+    }
+
+    [Fact]
+    public void DecodeQsQuery_ShouldDistinguishNameOnlyAndEmptyValues()
+    {
+        var uri = new Uri("https://example.com/search?flag&empty=#results");
+
+        var result = uri.DecodeQsQuery(new DecodeOptions { StrictNullHandling = true });
+
+        result.Should().BeEquivalentTo(new Dictionary<string, object?>
+        {
+            ["flag"] = null,
+            ["empty"] = string.Empty
+        });
+    }
+
+    [Fact]
+    public void DecodeQsQuery_ShouldRespectCustomDelimiter()
+    {
+        var uri = new Uri("https://example.com/search?a=b;c=d#results");
+
+        var result = uri.DecodeQsQuery(
+            new DecodeOptions { Delimiter = new StringDelimiter(";") }
+        );
+
+        result.Should().BeEquivalentTo(new Dictionary<string, object?>
+        {
+            ["a"] = "b",
+            ["c"] = "d"
+        });
+    }
+
+    [Theory]
+    [InlineData("https://example.com/search")]
+    [InlineData("https://example.com/search?")]
+    [InlineData("https://example.com/search?#results")]
+    [InlineData("https://example.com/search#results")]
+    public void DecodeQsQuery_ShouldReturnEmptyMapForAbsentOrEmptyAbsoluteQuery(string value)
+    {
+        var uri = new Uri(value);
+
+        var result = uri.DecodeQsQuery();
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("?a%5Bb%5D=x%26y+z", "a%5Bb%5D=x%26y+z")]
+    [InlineData("search?a%5Bb%5D=x%26y+z#frag", "a%5Bb%5D=x%26y+z")]
+    [InlineData("search?", "")]
+    [InlineData("search?#frag", "")]
+    [InlineData("search", "")]
+    [InlineData("#frag?not=query", "")]
+    public void DecodeQsQuery_ShouldExtractRelativeQueryWithoutFragment(
+        string value,
+        string query
+    )
+    {
+        var uri = new Uri(value, UriKind.Relative);
+
+        var result = uri.DecodeQsQuery();
+
+        result.Should().BeEquivalentTo(Qs.Decode(query));
+    }
+
+    [Fact]
+    public void DecodeQsQuery_ShouldDecodeOpaqueAbsoluteUriQuery()
+    {
+        var uri = new Uri("mailto:user@example.com?subject=a%26b#frag");
+
+        var result = uri.DecodeQsQuery();
+
+        result.Should().BeEquivalentTo(new Dictionary<string, object?>
+        {
+            ["subject"] = "a&b"
+        });
+    }
+
+    [Fact]
+    public void DecodeQsQuery_ShouldUseUriCanonicalizationForMalformedEscapes()
+    {
+        var uri = new Uri("https://example.com/search?bad=%ZZ&tail=%");
+
+        var result = uri.DecodeQsQuery();
+
+        result.Should().BeEquivalentTo(new Dictionary<string, object?>
+        {
+            ["bad"] = "%ZZ",
+            ["tail"] = "%"
+        });
+    }
+
+    [Fact]
+    public void DecodeQsQuery_ShouldThrowForNullUri()
+    {
+        Uri? uri = null;
+
+        var act = () => uri!.DecodeQsQuery();
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("uri");
+    }
+}

--- a/QsNet/Extensions.cs
+++ b/QsNet/Extensions.cs
@@ -1,7 +1,8 @@
-using QsNet.Models;
 #if NETSTANDARD2_0
+using System;
 using System.Collections.Generic;
 #endif
+using QsNet.Models;
 
 namespace QsNet;
 
@@ -15,6 +16,33 @@ namespace QsNet;
 public static class Extensions
 {
     /// <summary>
+    ///     Decode the escaped query component of a URI into a Dictionary.
+    /// </summary>
+    /// <param name="uri">The URI whose query component should be decoded</param>
+    /// <param name="options">Optional decoder settings</param>
+    /// <returns>A Dictionary containing the decoded key-value pairs</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="uri" /> is null</exception>
+    public static Dictionary<string, object?> DecodeQsQuery(
+        this Uri uri,
+        DecodeOptions? options = null
+    )
+    {
+#if NETSTANDARD2_0
+        if (uri is null)
+            throw new ArgumentNullException(nameof(uri));
+#else
+        ArgumentNullException.ThrowIfNull(uri);
+#endif
+
+        return Qs.Decode(
+            uri.IsAbsoluteUri
+                ? uri.GetComponents(UriComponents.Query, UriFormat.UriEscaped)
+                : GetRelativeQuery(uri.OriginalString),
+            options
+        );
+    }
+
+    /// <summary>
     ///     Decode a query string into a Dictionary.
     /// </summary>
     /// <param name="queryString">The query string to decode</param>
@@ -23,10 +51,8 @@ public static class Extensions
     public static Dictionary<string, object?> ToQueryMap(
         this string queryString,
         DecodeOptions? options = null
-    )
-    {
-        return Qs.Decode(queryString, options);
-    }
+    ) =>
+        Qs.Decode(queryString, options);
 
     /// <summary>
     ///     Encode a Dictionary into a query string.
@@ -37,8 +63,23 @@ public static class Extensions
     public static string ToQueryString(
         this Dictionary<string, object?> dictionary,
         EncodeOptions? options = null
-    )
+    ) =>
+        Qs.Encode(dictionary, options);
+
+    private static string GetRelativeQuery(string uri)
     {
-        return Qs.Encode(dictionary, options);
+        var queryStart = uri.IndexOf('?');
+        if (queryStart < 0)
+            return string.Empty;
+
+        var fragmentStart = uri.IndexOf('#');
+        if (fragmentStart >= 0 && queryStart > fragmentStart)
+            return string.Empty;
+
+        queryStart++;
+        var queryEnd = fragmentStart >= 0 ? fragmentStart : uri.Length;
+        return queryStart == queryEnd
+            ? string.Empty
+            : uri.Substring(queryStart, queryEnd - queryStart);
     }
 }

--- a/README.md
+++ b/README.md
@@ -217,6 +217,43 @@ string encoded = Qs.Encode(new Dictionary<string, object?> { ["a"] = "c" });
 
 ## Decoding
 
+### URI queries
+
+Use `DecodeQsQuery` to decode the escaped query component of an absolute or
+relative `Uri` without pre-decoding percent escapes or including the fragment:
+
+```csharp
+var uri = new Uri(
+    "https://example.com/search?filter%5Bwhere%5D%5Bname%5D=John%20Doe&tag=a&tag=b&flag&empty=#results"
+);
+
+var query = uri.DecodeQsQuery(
+    new DecodeOptions { StrictNullHandling = true }
+);
+// => { "filter": { "where": { "name": "John Doe" } }, "tag": ["a", "b"], "flag": null, "empty": "" }
+```
+
+Here, encoded brackets reach QsNet unchanged, the fragment is ignored, the two
+`tag` values use the configured duplicate handling, `flag` decodes as `null`,
+and `empty=` decodes as an empty string. An absent or empty query returns an
+empty dictionary.
+
+The helper is intentionally read-only. For a new URI with no existing query,
+construct the URI explicitly from default `Qs.Encode(...)` output:
+
+```csharp
+var values = new Dictionary<string, object?> { ["page"] = "2" };
+var encoded = Qs.Encode(values);
+var uri = new Uri($"https://api.example.com/products?{encoded}");
+```
+
+`AddQueryPrefix` is `false` by default. If you enable it, interpolate the
+encoded output without adding another literal `?`, or remove the prefix first.
+Do not use this pattern to merge with an arbitrary existing query: decoding and
+re-encoding can change duplicate ordering, name-only keys, delimiters, list
+notation, and percent spelling. `Encode = false` or a custom encoder can also
+produce text unsuitable for `Uri` construction.
+
 ### Nested dictionaries
 
 ```csharp

--- a/docs/docs/decoding.md
+++ b/docs/docs/decoding.md
@@ -1,5 +1,33 @@
 ## Decoding
 
+### URI queries
+
+Use `DecodeQsQuery` to decode the escaped query component of an absolute or
+relative `Uri` without pre-decoding percent escapes or including the fragment:
+
+```csharp
+var uri = new Uri(
+    "https://example.com/search?" +
+    "filter%5Bwhere%5D%5Bname%5D=John%20Doe&" +
+    "tag=a&tag=b&flag&empty=#results"
+);
+
+var query = uri.DecodeQsQuery(
+    new DecodeOptions { StrictNullHandling = true }
+);
+```
+
+Encoded brackets reach QsNet unchanged, the fragment is ignored, duplicate
+keys use the configured duplicate handling, and strict null handling preserves
+the difference between `flag` and `empty=`. Absolute and relative URIs are
+supported; an absent or empty query returns an empty dictionary.
+
+The helper does not mutate or round-trip the URI. For writes, prefer explicit
+construction from `Qs.Encode(...)` output or one of the host-specific adapter
+packages. Decoding and re-encoding an arbitrary existing query can change
+duplicate ordering, name-only keys, delimiters, list notation, and percent
+spelling.
+
 ### Nested dictionaries
 
 ```csharp


### PR DESCRIPTION
This pull request introduces a new extension method, `DecodeQsQuery`, for the `System.Uri` type, enabling robust decoding of percent-escaped query components from both absolute and relative URIs. It also adds comprehensive tests and updates documentation to reflect this new feature. The method ensures fragments are excluded, supports all QsNet decoder options, and is read-only by design.

**New Feature: URI Query Decoding**
- Added a `DecodeQsQuery` extension method to `System.Uri` that decodes the query component into a dictionary, supports both absolute and relative URIs, excludes fragments, and passes through all QsNet decoder options. The implementation includes null checks and handles edge cases such as empty or malformed queries. [[1]](diffhunk://#diff-28387509b8891fa88f28986a341517920cb275c93aa03560cc26c0e3645dc73eR18-R44) [[2]](diffhunk://#diff-28387509b8891fa88f28986a341517920cb275c93aa03560cc26c0e3645dc73eL40-R83) [[3]](diffhunk://#diff-28387509b8891fa88f28986a341517920cb275c93aa03560cc26c0e3645dc73eL26-R55) [[4]](diffhunk://#diff-28387509b8891fa88f28986a341517920cb275c93aa03560cc26c0e3645dc73eL1-R5)

**Testing**
- Introduced a new test suite in `QsNet.Tests/UriExtensionTests.cs` covering a wide range of scenarios for `DecodeQsQuery`, including structured queries, duplicate keys, options handling, empty and malformed queries, and error cases.
- Added new smoke tests in `.github/workflows/test.yml` to validate `DecodeQsQuery` handling of absolute and relative URIs and regression checks for nested and encoded parameters. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R202-R211) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R365-R374) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R307-R309)

**Documentation**
- Updated `README.md` and `docs/docs/decoding.md` with usage examples, caveats, and guidance for the new `DecodeQsQuery` method, emphasizing its read-only nature and best practices for URI query manipulation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R220-R256) [[2]](diffhunk://#diff-11e598b29761973679cfd9d320b364e5607ceb3867e6d9961ed38afc21dd1ba7R3-R30)

**Changelog**
- Added an entry for version 1.4.4-dev describing the new feature and its capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DecodeQsQuery()` extension method for decoding query components from URI objects with support for absolute and relative URIs, excluding fragments and preserving escape sequences until decoding.

* **Documentation**
  * Updated documentation with examples and best practices for URI query decoding.

* **Tests**
  * Added comprehensive test coverage for URI query decoding functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->