### PR TITLE
:sparkles: qs.js 6.15.3 parity 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.1-dev
+
+* [FIX] match Node `qs` 6.15.3 cumulative list-limit enforcement across duplicate, comma, and mixed list merges, including pre-split rejection of oversized flat comma values
+* [FIX] align lenient unbalanced-bracket handling and preserve multi-step cyclic dictionary identity during decoding
+* [CHORE] update the comparison baseline to `qs` 6.15.3 and pnpm 11.9.0, with regression coverage for the new upstream behavior
+
 ## 1.5.0
 
 * [DOCS] document using core `QsNet` with RestEase's `[RawQueryString]` parameter, including query-composition and double-encoding guidance, and extend the QsNet usage skill with the same integration guidance

--- a/README.md
+++ b/README.md
@@ -466,7 +466,9 @@ Qs.Decode("a[]=&a[]=b");
 list entries only when `index < ListLimit`; an index at or above the limit
 becomes a dictionary entry by default, or throws when `ThrowOnLimitExceeded` is
 true. Implicit list growth, comma lists, and duplicate-combine paths use the same
-element count before overflow conversion or exception.
+element count before overflow conversion or exception. Overflow conversion
+preserves every value in a numeric-keyed dictionary. List parsing is disabled
+only when `ParseLists` is false; top-level parameter count does not change it.
 
 Large indices convert to a dictionary by default:
 

--- a/docs/docs/decoding.md
+++ b/docs/docs/decoding.md
@@ -70,7 +70,7 @@ Qs.Decode("a=b&c=d", new DecodeOptions { ParameterLimit = 1 });
 - Empty query segments and empty keys are ignored before `ParameterLimit` accounting.
 - Comma-list limit behavior is deterministic:
   - `ThrowOnLimitExceeded = true` throws on overflow.
-  - `ThrowOnLimitExceeded = false` truncates to the remaining list capacity.
+  - `ThrowOnLimitExceeded = false` preserves every value in a numeric-keyed overflow dictionary.
 - Some JavaScript `qs` edge-case limitations are intentionally fixed rather than mirrored.
 
 ### Ignore leading `?`
@@ -196,7 +196,9 @@ Qs.Decode("a[]=&a[]=b");
 list entries only when `index < ListLimit`; an index at or above the limit
 becomes a dictionary entry by default, or throws when `ThrowOnLimitExceeded` is
 true. Implicit list growth, comma lists, and duplicate-combine paths use the same
-element count before overflow conversion or exception.
+element count before overflow conversion or exception. Overflow conversion
+preserves every value in a numeric-keyed dictionary. List parsing is disabled
+only when `ParseLists` is false; top-level parameter count does not change it.
 
 Large indices convert to a dictionary by default:
 

--- a/skills/qsnet/SKILL.md
+++ b/skills/qsnet/SKILL.md
@@ -384,8 +384,12 @@ Use these options with `Qs.Decode(query, new DecodeOptions { ... })`:
 - Empty list tokens such as `foo[]`: `AllowEmptyLists = true`.
 - Sparse numeric indices: `AllowSparseLists = true` preserves holes as `null`
   entries; the default compacts lists.
-- Large or sparse list indices: default `ListLimit` is `20`; indices above the
-  limit become dictionary keys or are limited according to the merge path.
+- List limits: default `ListLimit` is `20`; explicit numeric indices at or above
+  the limit become dictionary keys. Implicit, comma, duplicate, and mixed list
+  growth that exceeds the limit becomes a numeric-keyed dictionary preserving
+  every value, or throws when `ThrowOnLimitExceeded = true`.
+- List parsing is disabled only by `ParseLists = false`; the number of top-level
+  parameters does not change list parsing.
 - Comma-separated values such as `a=b,c`: `Comma = true`.
 - Tokens without `=` as `null`: `StrictNullHandling = true`.
 - Custom delimiters: `Delimiter = new StringDelimiter(";")` or
@@ -503,7 +507,8 @@ Warn or adjust before giving code for these cases:
 - `DecodeOptions { DecodeDotInKeys = true, AllowDots = false }` is invalid.
 - `ParameterLimit` must be positive.
 - `ThrowOnLimitExceeded = true` turns parameter and list limit violations into
-  exceptions; without it, parsing truncates or falls back where possible.
+  exceptions. Without it, parameter parsing stops at `ParameterLimit`, while
+  list overflow becomes a numeric-keyed dictionary that preserves every value.
 - `StrictDepth = true` throws on well-formed depth overflow; with the default
   `false`, the remainder beyond `Depth` is kept as a trailing key segment.
 - Built-in charset handling supports UTF-8 and ISO-8859-1/Latin1; other

--- a/src/QsNet/Internal/Decoder.cs
+++ b/src/QsNet/Internal/Decoder.cs
@@ -41,13 +41,13 @@ internal static class Decoder
     /// <param name="value">The value to parse, which can be a string or any other type.</param>
     /// <param name="options">The decoding options that affect how the value is parsed.</param>
     /// <param name="currentListLength">The current length of the list being parsed, used for limit checks.</param>
-    /// <param name="enforceListLimit">Whether to enforce comma-split list limits for this value.</param>
+    /// <param name="isFlatListValue">Whether this value is a flat comma list rather than a bracket-array group.</param>
     /// <returns>The parsed value, which may be a List or the original value if no parsing is needed.</returns>
     private static object? ParseListValue(
         object? value,
         DecodeOptions options,
         int currentListLength,
-        bool enforceListLimit = true
+        bool isFlatListValue = true
     )
     {
         if (options is { ListLimit: < 0, Comma: false })
@@ -58,18 +58,26 @@ internal static class Decoder
             var idx = str.IndexOf(',');
             if (idx >= 0)
             {
+                if (isFlatListValue && options.ThrowOnLimitExceeded)
+                {
+                    var commaCount = 0;
+                    var commaIndex = idx;
+                    while (commaIndex >= 0)
+                    {
+                        commaCount++;
+                        if (commaCount >= options.ListLimit)
+                            throw Utils.CreateListLimitExceededException(options.ListLimit);
+
+                        commaIndex = str.IndexOf(',', commaIndex + 1);
+                    }
+                }
+
                 var list = new List<object?>();
                 var start = 0;
 
                 while (true)
                 {
                     var end = idx >= 0 ? idx : str.Length;
-                    if (enforceListLimit && options.ThrowOnLimitExceeded)
-                        if (currentListLength + list.Count >= options.ListLimit)
-                            throw new InvalidOperationException(
-                                $"List limit exceeded. Only {options.ListLimit} element{(options.ListLimit == 1 ? "" : "s")} allowed in a list."
-                            );
-
                     list.Add(str.Substring(start, end - start));
 
                     if (idx < 0)
@@ -80,7 +88,7 @@ internal static class Decoder
                 }
 
                 if (
-                    enforceListLimit
+                    isFlatListValue
                     && list.Count > options.ListLimit
                 )
                     return Utils.MarkListOverflow(list);
@@ -90,9 +98,7 @@ internal static class Decoder
         }
 
         if (options is { ListLimit: >= 0, ThrowOnLimitExceeded: true } && currentListLength >= options.ListLimit)
-            throw new InvalidOperationException(
-                $"List limit exceeded. Only {options.ListLimit} element{(options.ListLimit == 1 ? "" : "s")} allowed in a list."
-            );
+            throw Utils.CreateListLimitExceededException(options.ListLimit);
 
         return value;
     }
@@ -442,7 +448,10 @@ internal static class Decoder
 
         var leaf = valuesParsed ? value : ParseListValue(value, options, currentListLength);
 
-        if (leaf is IDictionary id and not Dictionary<object, object?>)
+        if (
+            leaf is IDictionary id and not Dictionary<object, object?>
+            && (valuesParsed || id is not Dictionary<string, object?>)
+        )
         {
             // Preserve identity for self-referencing maps
             var selfRef = false;
@@ -493,47 +502,6 @@ internal static class Decoder
                 var cleanRoot = root.StartsWith('[') && root.EndsWith(']') ? root[1..^1] : root;
 #endif
 
-                // Why does `opens > closes` imply the trailing ']' is synthetic?
-                // SplitKeyIntoSegments() wraps any overflow/unterminated remainder exactly once:
-                //   segments.Add("[" + remainder + "]");
-                // Here we've already removed that outer wrapper (cleanRoot = root[1..^1]).
-                // If the remaining inner text has more '[' than ']' and *still* ends with ']',
-                // that last ']' cannot be balancing any '[' from the inner text — it's the
-                // closing bracket from the synthetic wrapper that leaked into this inner slice.
-                // Trimming it recovers the literal remainder (e.g., "[[b[c]]" → cleanRoot "[b[c]" → trim → "[b[c").
-#if NETSTANDARD2_0
-                if (root.Length >= 2 && root[0] == '[' && root[root.Length - 1] == ']')
-#else
-                if (root is ['[', _, ..] && root[^1] == ']')
-#endif
-                {
-                    var inner = cleanRoot;
-                    int opens = 0, closes = 0;
-                    foreach (var ch2 in inner)
-                        switch (ch2)
-                        {
-                            case '[':
-                                opens++;
-                                break;
-                            case ']':
-                                closes++;
-                                break;
-                        }
-
-#if NETSTANDARD2_0
-                    if (opens > closes && inner.Length > 0 && inner[inner.Length - 1] == ']')
-#else
-                    if (opens > closes && inner.Length > 0 && inner[^1] == ']')
-#endif
-                    {
-#if NETSTANDARD2_0
-                        cleanRoot = inner.Substring(0, inner.Length - 1);
-#else
-                        cleanRoot = inner[..^1];
-#endif
-                    }
-                }
-
                 string decodedRoot;
 #if NETSTANDARD2_0
                 decodedRoot = options.DecodeDotInKeys &&
@@ -567,9 +535,7 @@ internal static class Decoder
                             obj = list;
                             break;
                         case true when idx >= 0 && options.ThrowOnLimitExceeded:
-                            throw new InvalidOperationException(
-                                $"List limit exceeded. Only {options.ListLimit} element{(options.ListLimit == 1 ? "" : "s")} allowed in a list."
-                            );
+                            throw Utils.CreateListLimitExceededException(options.ListLimit);
                         case true:
                             // Not a list (e.g., idx > ListLimit) → map with the string key (e.g., "2", "99999999")
                             obj = Utils.MarkOverflow(
@@ -725,7 +691,6 @@ internal static class Decoder
 
         var open = first;
         var depth = 0;
-        var lastClose = -1;
         var brokeUnterminated = false;
         while (open >= 0 && depth < maxDepth)
         {
@@ -761,7 +726,6 @@ internal static class Decoder
 #else
             segments.Add(key[open..(close + 1)]); // balanced group, e.g. "[b[c]]"
 #endif
-            lastClose = close;
             depth++;
             open = key.IndexOf('[', close + 1);
         }
@@ -798,24 +762,7 @@ internal static class Decoder
             return segments;
         }
 
-        // Otherwise, handle any *trailing text* that comes after the last balanced group,
-        // like "a[b]c" → remainder "c". Ignore a lone trailing '.' (degenerate top‑level dot).
-        if (lastClose < 0 || lastClose + 1 >= key.Length)
-            return segments;
-
-        string trailing;
-#if NETSTANDARD2_0
-        trailing = key.Substring(lastClose + 1);
-#else
-        trailing = key[(lastClose + 1)..];
-#endif
-        if (trailing == ".") return segments;
-        if (strictDepth)
-            throw new InvalidOperationException(
-                $"Input depth exceeded depth option of {maxDepth} and strictDepth is true"
-            );
-        segments.Add("[" + trailing + "]");
-
+        // qs ignores text after the final balanced bracket group (for example, "a[b]extra").
         return segments;
     }
 

--- a/src/QsNet/Internal/Decoder.cs
+++ b/src/QsNet/Internal/Decoder.cs
@@ -50,9 +50,6 @@ internal static class Decoder
         bool isFlatListValue = true
     )
     {
-        if (options is { ListLimit: < 0, Comma: false })
-            return value;
-
         if (value is string str && options.Comma && str.Length != 0)
         {
             var idx = str.IndexOf(',');
@@ -97,7 +94,7 @@ internal static class Decoder
             }
         }
 
-        if (options is { ListLimit: >= 0, ThrowOnLimitExceeded: true } && currentListLength >= options.ListLimit)
+        if (options.ThrowOnLimitExceeded && currentListLength >= options.ListLimit)
             throw Utils.CreateListLimitExceededException(options.ListLimit);
 
         return value;
@@ -474,12 +471,9 @@ internal static class Decoder
 
             if (root == "[]")
             {
-                // If lists are disabled or list parsing is off, do not create lists.
-                if (!options.ParseLists || options.ListLimit < 0)
+                // If list parsing is disabled, do not create lists.
+                if (!options.ParseLists)
                 {
-                    if (options is { ListLimit: < 0, ThrowOnLimitExceeded: true })
-                        throw new InvalidOperationException("Lists are disabled (ListLimit < 0).");
-
                     // Degrade to a map: treat the first element as index "0".
                     obj = new Dictionary<object, object?> { ["0"] = leaf };
                 }
@@ -522,7 +516,7 @@ internal static class Decoder
                 var isBracketedNumeric =
                     isPureNumeric && root != decodedRoot && idx.ToString(CultureInfo.InvariantCulture) == decodedRoot;
 
-                if (!options.ParseLists || options.ListLimit < 0)
+                if (!options.ParseLists)
                     obj = new Dictionary<object, object?> { [decodedRoot] = leaf };
                 else
                     switch (isBracketedNumeric)

--- a/src/QsNet/Internal/MergeFrame.cs
+++ b/src/QsNet/Internal/MergeFrame.cs
@@ -60,7 +60,7 @@ internal sealed class MergeFrame(object? target, object? source, DecodeOptions o
     }
 
     public object? Target { get; } = target;
-    public object? Source { get; } = source;
+    public object? Source { get; set; } = source;
     public DecodeOptions Options { get; } = options;
     public MergePhase Phase { get; set; } = MergePhase.Start;
     public MergeAssignment Assignment { get; } = MergeAssignment.Root;

--- a/src/QsNet/Internal/Utils.cs
+++ b/src/QsNet/Internal/Utils.cs
@@ -1109,7 +1109,7 @@ internal static partial class Utils
     /// </summary>
     private static object EnforceListLimit(List<object?> values, DecodeOptions options)
     {
-        if (options.ListLimit < 0 || values.Count <= options.ListLimit)
+        if (values.Count <= options.ListLimit)
             return values;
 
         return options.ThrowOnLimitExceeded
@@ -1221,9 +1221,6 @@ internal static partial class Utils
     /// </exception>
     internal static object CombineWithLimit(object? a, object? b, DecodeOptions options)
     {
-        if (options.ListLimit < 0)
-            return Combine<object?>(a, b);
-
         if (!IsOverflow(a)) return EnforceListLimit(Combine<object?>(a, b), options);
         var target = (IDictionary)a!;
         var nextIndex = GetOverflowMaxIndex(target) + 1;

--- a/src/QsNet/Internal/Utils.cs
+++ b/src/QsNet/Internal/Utils.cs
@@ -215,18 +215,18 @@ internal static partial class Utils
                                         switch (currentSource)
                                         {
                                             case IEnumerable<object?> srcIter:
-                                                var appendIndex = targetMaxIndex;
+                                                var indexedSource = new Dictionary<object, object?>();
+                                                var sourceIndex = 0;
                                                 foreach (var item in srcIter)
                                                 {
-                                                    appendIndex++;
-                                                    if (item is Undefined)
-                                                        continue;
-
-                                                    mutable[appendIndex.ToString(CultureInfo.InvariantCulture)] = item;
+                                                    if (item is not Undefined)
+                                                        indexedSource[
+                                                            sourceIndex.ToString(CultureInfo.InvariantCulture)
+                                                        ] = item;
+                                                    sourceIndex++;
                                                 }
 
-                                                SetOverflowMaxIndex(mutable, appendIndex);
-                                                Complete(frame, mutable);
+                                                frame.Source = indexedSource;
                                                 continue;
                                             case Undefined:
                                                 Complete(frame, mutable);

--- a/src/QsNet/Internal/Utils.cs
+++ b/src/QsNet/Internal/Utils.cs
@@ -145,7 +145,7 @@ internal static partial class Utils
                                             frame,
                                             currentTarget is ISet<object?>
                                                 ? new HashSet<object?>(indexMap.Values)
-                                                : CopyToList(indexMap.Values)
+                                                : EnforceListLimit(CopyToList(indexMap.Values), opts)
                                         );
                                         continue;
                                     }
@@ -186,7 +186,7 @@ internal static partial class Utils
                                             if (v is not Undefined)
                                                 res.Add(v);
 
-                                        Complete(frame, res);
+                                        Complete(frame, EnforceListLimit(res, opts));
                                         continue;
                                     }
 
@@ -200,7 +200,7 @@ internal static partial class Utils
                                     var appended = new List<object?>(targetList.Count + 1);
                                     appended.AddRange(targetList);
                                     appended.Add(currentSource);
-                                    Complete(frame, appended);
+                                    Complete(frame, EnforceListLimit(appended, opts));
                                     continue;
 
                                 case IDictionary targetMap:
@@ -285,7 +285,7 @@ internal static partial class Utils
                                         if (v is not Undefined)
                                             list.Add(v);
 
-                                    Complete(frame, list);
+                                    Complete(frame, EnforceListLimit(list, opts));
                                     continue;
                             }
 
@@ -367,7 +367,13 @@ internal static partial class Utils
                                     continue;
                                 }
 
-                                Complete(frame, new List<object?> { currentTarget, ToObjectKeyedDictionary(sourceMap) });
+                                Complete(
+                                    frame,
+                                    EnforceListLimit(
+                                        [currentTarget, ToObjectKeyedDictionary(sourceMap)],
+                                        opts
+                                    )
+                                );
                                 continue;
                         }
 
@@ -433,7 +439,7 @@ internal static partial class Utils
                                 frame,
                                 frame.TargetIsSet
                                     ? new HashSet<object?>(indexed.Values)
-                                    : CopyToList(indexed.Values)
+                                    : EnforceListLimit(CopyToList(indexed.Values), frame.Options)
                             );
                             continue;
                         }
@@ -1089,6 +1095,29 @@ internal static partial class Utils
     }
 
     /// <summary>
+    ///     Creates the standard exception used when list growth exceeds the configured limit.
+    /// </summary>
+    /// <param name="listLimit">Configured maximum list size.</param>
+    /// <returns>The exception to throw.</returns>
+    internal static InvalidOperationException CreateListLimitExceededException(int listLimit) =>
+        new(
+            $"List limit exceeded. Only {listLimit} element{(listLimit == 1 ? "" : "s")} allowed in a list."
+        );
+
+    /// <summary>
+    ///     Keeps an in-limit list, throws in strict mode, or converts all values to an overflow map.
+    /// </summary>
+    private static object EnforceListLimit(List<object?> values, DecodeOptions options)
+    {
+        if (options.ListLimit < 0 || values.Count <= options.ListLimit)
+            return values;
+
+        return options.ThrowOnLimitExceeded
+            ? throw CreateListLimitExceededException(options.ListLimit)
+            : MarkListOverflow(values);
+    }
+
+    /// <summary>
     ///     Indicates whether an object has been marked as a list-overflow dictionary.
     /// </summary>
     /// <param name="obj">Candidate object.</param>
@@ -1100,14 +1129,16 @@ internal static partial class Utils
     /// </summary>
     /// <param name="obj">Overflow-marked object.</param>
     /// <returns>The tracked max index, or <c>-1</c> when not tracked.</returns>
-    private static int GetOverflowMaxIndex(object obj) => OverflowTable.TryGetValue(obj, out var state) ? state.MaxIndex : -1;
+    private static int GetOverflowMaxIndex(object obj) =>
+        OverflowTable.TryGetValue(obj, out var state) ? state.MaxIndex : -1;
 
     /// <summary>
     ///     Updates overflow metadata with the latest maximum numeric index.
     /// </summary>
     /// <param name="obj">Overflow-marked object.</param>
     /// <param name="maxIndex">Newest maximum index.</param>
-    private static void SetOverflowMaxIndex(object obj, int maxIndex) => OverflowTable.GetOrCreateValue(obj).MaxIndex = maxIndex;
+    private static void SetOverflowMaxIndex(object obj, int maxIndex) =>
+        OverflowTable.GetOrCreateValue(obj).MaxIndex = maxIndex;
 
     /// <summary>
     ///     Marks an object as overflowed and stores its current maximum numeric index.
@@ -1126,7 +1157,8 @@ internal static partial class Utils
     /// </summary>
     /// <param name="list">List to convert.</param>
     /// <returns>An overflow dictionary preserving all list values and the highest index.</returns>
-    internal static Dictionary<object, object?> MarkListOverflow(List<object?> list) => (Dictionary<object, object?>)MarkOverflow(ListToIndexMap(list), list.Count - 1);
+    internal static Dictionary<object, object?> MarkListOverflow(List<object?> list) =>
+        (Dictionary<object, object?>)MarkOverflow(ListToIndexMap(list), list.Count - 1);
 
     /// <summary>
     ///     Tries to parse a key as a canonical non-negative array index.
@@ -1192,31 +1224,17 @@ internal static partial class Utils
         if (options.ListLimit < 0)
             return Combine<object?>(a, b);
 
-        if (IsOverflow(a))
-        {
-            var target = (IDictionary)a!;
-            var nextIndex = GetOverflowMaxIndex(target) + 1;
-            if (options.ThrowOnLimitExceeded && nextIndex >= options.ListLimit)
-                throw new InvalidOperationException(
-                    $"List limit exceeded. Only {options.ListLimit} element{(options.ListLimit == 1 ? "" : "s")} allowed in a list."
-                );
-
-            // Overflow dictionaries continue accepting appended values using synthetic numeric-string keys.
-            target[nextIndex.ToString(CultureInfo.InvariantCulture)] = b;
-            SetOverflowMaxIndex(target, nextIndex);
-            return target;
-        }
-
-        var combined = Combine<object?>(a, b);
-        if (combined.Count <= options.ListLimit)
-            return combined;
-
+        if (!IsOverflow(a)) return EnforceListLimit(Combine<object?>(a, b), options);
+        var target = (IDictionary)a!;
+        var nextIndex = GetOverflowMaxIndex(target) + 1;
         if (options.ThrowOnLimitExceeded)
-            throw new InvalidOperationException(
-                $"List limit exceeded. Only {options.ListLimit} element{(options.ListLimit == 1 ? "" : "s")} allowed in a list."
-            );
+            throw CreateListLimitExceededException(options.ListLimit);
 
-        return MarkOverflow(ListToIndexMap(combined), combined.Count - 1);
+        // Overflow dictionaries continue accepting appended values using synthetic numeric-string keys.
+        target[nextIndex.ToString(CultureInfo.InvariantCulture)] = b;
+        SetOverflowMaxIndex(target, nextIndex);
+        return target;
+
     }
 
     /// <summary>
@@ -1454,7 +1472,8 @@ internal static partial class Utils
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>
-    internal static object? ConvertNestedValues(object? value) => ConvertNestedValues(value, new HashSet<object>(ReferenceEqualityComparer.Instance));
+    internal static object? ConvertNestedValues(object? value) =>
+        ConvertNestedValues(value, new HashSet<object>(ReferenceEqualityComparer.Instance));
 
     /// <summary>
     ///     Recursively converts nested values in a structure, handling circular references.
@@ -1474,7 +1493,7 @@ internal static partial class Utils
                 var keysArr = new object[dict.Count];
                 keysCol.CopyTo(keysArr, 0);
                 foreach (var key in keysArr) dict[key] = ConvertNestedValues(dict[key], visited);
-                return NormalizeForTarget(dict);
+                return dict is Dictionary<string, object?> ? dict : NormalizeForTarget(dict);
 
             case IList list:
                 for (var i = 0; i < list.Count; i++)
@@ -1520,6 +1539,12 @@ internal static partial class Utils
         Dictionary<object, object?> enumerableCache
     )
     {
+        if (
+            enumerableCache.TryGetValue(dict, out var cached)
+            && cached is Dictionary<string, object?> cachedDictionary
+        )
+            return cachedDictionary;
+
         // If we've already seen this dictionary, don't descend again.
         // If it's already string-keyed, just return it to preserve identity.
         if (!visited.Add(dict))
@@ -1535,6 +1560,7 @@ internal static partial class Utils
         }
 
         var result = new Dictionary<string, object?>(dict.Count);
+        enumerableCache[dict] = result;
 
         foreach (DictionaryEntry entry in dict)
         {
@@ -1543,9 +1569,7 @@ internal static partial class Utils
 
             item = item switch
             {
-                IDictionary child when ReferenceEquals(child, dict) =>
-                    // Direct self-reference: keep the same instance to preserve identity
-                    child,
+                IDictionary child when ReferenceEquals(child, dict) => result,
                 _ => NormalizeDictionaryValue(item, visited, enumerableCache)
             };
 

--- a/src/QsNet/Qs.cs
+++ b/src/QsNet/Qs.cs
@@ -55,10 +55,6 @@ public static class Qs
             _ => new Dictionary<string, object?>()
         };
 
-        var finalOptions = opts;
-        if (opts is { ParseLists: true, ListLimit: > 0 } && tempObj.Count > opts.ListLimit)
-            finalOptions = opts.CopyWith(parseLists: false);
-
         var decodeFromString = input is string;
 
         if (tempObj.Count == 0)
@@ -67,7 +63,7 @@ public static class Qs
         var structuredScan = StructuredKeyScan.Empty;
         if (decodeFromString)
         {
-            structuredScan = ScanStructuredKeys(tempObj, finalOptions);
+            structuredScan = ScanStructuredKeys(tempObj, opts);
             if (!structuredScan.HasAnyStructuredSyntax)
             {
                 var flatObj = new Dictionary<object, object?>(tempObj.Count);
@@ -94,13 +90,13 @@ public static class Qs
             )
             {
                 obj[key] = obj.TryGetValue(key, out var existing)
-                    ? Utils.Merge(existing, value, finalOptions)
+                    ? Utils.Merge(existing, value, opts)
                     : value;
 
                 continue;
             }
 
-            var parsed = Decoder.ParseKeys(key, value, finalOptions, decodeFromString);
+            var parsed = Decoder.ParseKeys(key, value, opts, decodeFromString);
 
             if (parsed is null)
                 continue;
@@ -113,7 +109,7 @@ public static class Qs
             }
 
             obj = NormalizeObjectMap(
-                Utils.Merge(obj, parsed, finalOptions)
+                Utils.Merge(obj, parsed, opts)
             );
         }
 

--- a/tests/QsNet.Tests/DecodeTests.cs
+++ b/tests/QsNet.Tests/DecodeTests.cs
@@ -5820,6 +5820,61 @@ public partial class DecodeTest
     }
 
     [Fact]
+    public void Decode_Qs6153_OverflowValuesMergeWithBracketAssignments()
+    {
+        var cases = new (string Query, int ListLimit, Dictionary<string, object?> Expected)[]
+        {
+            (
+                "a=1,2&a[]=x",
+                1,
+                new Dictionary<string, object?>
+                {
+                    ["0"] = new List<object?> { "1", "x" },
+                    ["1"] = "2"
+                }
+            ),
+            (
+                "a[]=x&a=1,2",
+                1,
+                new Dictionary<string, object?>
+                {
+                    ["0"] = new List<object?> { "x", "1" },
+                    ["1"] = "2"
+                }
+            ),
+            (
+                "a=x&a=x&a[]=x",
+                1,
+                new Dictionary<string, object?>
+                {
+                    ["0"] = new List<object?> { "x", "x" },
+                    ["1"] = "x"
+                }
+            ),
+            (
+                "a=1,2&a[2]=z&a[]=x",
+                2,
+                new Dictionary<string, object?>
+                {
+                    ["0"] = new List<object?> { "1", "x" },
+                    ["1"] = "2",
+                    ["2"] = "z"
+                }
+            )
+        };
+
+        foreach (var (query, listLimit, expected) in cases)
+        {
+            var decoded = Qs.Decode(
+                query,
+                new DecodeOptions { Comma = true, ListLimit = listLimit }
+            );
+
+            decoded["a"].Should().BeEquivalentTo(expected, because: query);
+        }
+    }
+
+    [Fact]
     public void Decode_Qs6153_OversizedFlatCommaValueThrowsBeforeDecoding()
     {
         var decodedValues = 0;

--- a/tests/QsNet.Tests/DecodeTests.cs
+++ b/tests/QsNet.Tests/DecodeTests.cs
@@ -3179,7 +3179,30 @@ public partial class DecodeTest
         var options = new DecodeOptions { ListLimit = -1, ThrowOnLimitExceeded = true };
 
         Action act = () => Qs.Decode("a[]=1&a[]=2", options);
-        act.Should().Throw<InvalidOperationException>();
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("List limit exceeded. Only -1 elements allowed in a list.");
+    }
+
+    [Fact]
+    public void Decode_NegativeListLimit_ConvertsDuplicateGrowthToOverflowMap()
+    {
+        Qs.Decode("a=x&a=y", new DecodeOptions { ListLimit = -1 })
+            .Should()
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = new Dictionary<string, object?> { ["0"] = "x", ["1"] = "y" }
+                }
+            );
+
+        Action act = () => Qs.Decode(
+            "a=x&a=y",
+            new DecodeOptions { ListLimit = -1, ThrowOnLimitExceeded = true }
+        );
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("List limit exceeded. Only -1 elements allowed in a list.");
     }
 
     [Fact]

--- a/tests/QsNet.Tests/DecodeTests.cs
+++ b/tests/QsNet.Tests/DecodeTests.cs
@@ -38,19 +38,111 @@ public partial class DecodeTest
     }
 
     [Fact]
-    public void SplitKeyIntoSegments_StrictDepthThrowsOnTrailingText()
+    public void SplitKeyIntoSegments_StrictDepthIgnoresTrailingText()
     {
-        Action act = () => InternalDecoder.SplitKeyIntoSegments("a[b]c", false, 1, true);
-        act.Should()
-            .Throw<InvalidOperationException>()
-            .WithMessage("Input depth exceeded depth option of 1 and strictDepth is true");
+        var segments = InternalDecoder.SplitKeyIntoSegments("a[b]c", false, 1, true);
+
+        segments.Should().Equal("a", "[b]");
     }
 
     [Fact]
-    public void SplitKeyIntoSegments_AppendsTrailingSegmentWhenNotStrict()
+    public void SplitKeyIntoSegments_IgnoresTrailingTextWhenNotStrict()
     {
         var segments = InternalDecoder.SplitKeyIntoSegments("a[b]c", false, 2, false);
-        segments.Should().Contain("[c]");
+
+        segments.Should().Equal("a", "[b]");
+    }
+
+    [Fact]
+    public void Decode_CharacterizesUnbalancedBracketKeysLikeQs6153()
+    {
+        var cases = new (string Query, DecodeOptions Options, Dictionary<string, object?> Expected)[]
+        {
+            ("a[bc=v", new DecodeOptions(), new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?> { ["[bc"] = "v" }
+            }),
+            ("a[=v", new DecodeOptions(), new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?> { ["["] = "v" }
+            }),
+            ("a[b][c=v", new DecodeOptions(), new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?>
+                {
+                    ["b"] = new Dictionary<string, object?> { ["[c"] = "v" }
+                }
+            }),
+            ("a[b]c[d=v", new DecodeOptions(), new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?>
+                {
+                    ["b"] = new Dictionary<string, object?> { ["[d"] = "v" }
+                }
+            }),
+            ("filters[customtags:Env: Prod=v", new DecodeOptions(), new Dictionary<string, object?>
+            {
+                ["filters"] = new Dictionary<string, object?> { ["[customtags:Env: Prod"] = "v" }
+            }),
+            ("][a=v", new DecodeOptions(), new Dictionary<string, object?>
+            {
+                ["]"] = new Dictionary<string, object?> { ["[a"] = "v" }
+            }),
+            ("a][b=v", new DecodeOptions(), new Dictionary<string, object?>
+            {
+                ["a]"] = new Dictionary<string, object?> { ["[b"] = "v" }
+            }),
+            ("a[b[c=v", new DecodeOptions(), new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?> { ["[b[c"] = "v" }
+            }),
+            ("a[b[c]=v", new DecodeOptions(), new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?> { ["[b[c]"] = "v" }
+            }),
+            ("a[b][c[d=v", new DecodeOptions(), new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?>
+                {
+                    ["b"] = new Dictionary<string, object?> { ["[c[d"] = "v" }
+                }
+            }),
+            ("[abc=v", new DecodeOptions(), new Dictionary<string, object?> { ["[abc"] = "v" }),
+            ("[[]b=v", new DecodeOptions(), new Dictionary<string, object?> { ["[[]b"] = "v" }),
+            ("a[b]c[d]e[f=v", new DecodeOptions { Depth = 5 }, new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?>
+                {
+                    ["b"] = new Dictionary<string, object?>
+                    {
+                        ["d"] = new Dictionary<string, object?> { ["[f"] = "v" }
+                    }
+                }
+            }),
+            ("a[b]c[d]e[f=v", new DecodeOptions { Depth = 1 }, new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?>
+                {
+                    ["b"] = new Dictionary<string, object?> { ["[d]e[f"] = "v" }
+                }
+            }),
+            ("a[bc=v", new DecodeOptions { Depth = 0 }, new Dictionary<string, object?> { ["a[bc"] = "v" }),
+            ("a.b[c=v", new DecodeOptions { AllowDots = true }, new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?>
+                {
+                    ["b"] = new Dictionary<string, object?> { ["[c"] = "v" }
+                }
+            }),
+            ("a]b=v", new DecodeOptions(), new Dictionary<string, object?> { ["a]b"] = "v" }),
+            ("a[b]extra=v", new DecodeOptions(), new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?> { ["b"] = "v" }
+            })
+        };
+
+        foreach (var (query, options, expected) in cases)
+            Qs.Decode(query, options).Should().BeEquivalentTo(expected, because: query);
     }
 
     [Fact]
@@ -5453,7 +5545,7 @@ public partial class DecodeTest
             .BeEquivalentTo(
                 new Dictionary<string, object?>
                 {
-                    ["a"] = new Dictionary<string, object?> { ["[b[c"] = "x" }
+                    ["a"] = new Dictionary<string, object?> { ["[b[c]"] = "x" }
                 }
             );
     }
@@ -5670,6 +5762,155 @@ public partial class DecodeTest
 
         Action act = () => Qs.Decode("a=1&a=2", opts);
         act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Theory]
+    [InlineData("a=x&a[0]=y")]
+    [InlineData("a[0]=x&a=y")]
+    [InlineData("a[0]=x&a[]=y")]
+    public void Decode_Qs6153_MixedListGrowthThrowsPastLimit(string query)
+    {
+        var options = new DecodeOptions { ListLimit = 1, ThrowOnLimitExceeded = true };
+
+        Action act = () => Qs.Decode(query, options);
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("List limit exceeded. Only 1 element allowed in a list.");
+    }
+
+    [Theory]
+    [InlineData("a=x&a[0]=y")]
+    [InlineData("a[0]=x&a=y")]
+    [InlineData("a[0]=x&a[]=y")]
+    public void Decode_Qs6153_MixedListGrowthBecomesOverflowMap(string query)
+    {
+        var decoded = Qs.Decode(query, new DecodeOptions { ListLimit = 1 });
+
+        decoded.Should().BeEquivalentTo(
+            new Dictionary<string, object?>
+            {
+                ["a"] = new Dictionary<string, object?> { ["0"] = "x", ["1"] = "y" }
+            }
+        );
+    }
+
+    [Fact]
+    public void Decode_Qs6153_CumulativeCommaGrowthThrowsAfterDecodingAllValues()
+    {
+        var decodedValues = 0;
+        var options = new DecodeOptions
+        {
+            Comma = true,
+            ListLimit = 5,
+            ThrowOnLimitExceeded = true,
+            DecoderWithKind = (value, _, kind) =>
+            {
+                if (kind == DecodeKind.Value)
+                    decodedValues++;
+
+                return value;
+            }
+        };
+
+        Action act = () => Qs.Decode("a=1,2,3&a=4,5,6", options);
+
+        act.Should().Throw<InvalidOperationException>();
+        decodedValues.Should().Be(6);
+    }
+
+    [Fact]
+    public void Decode_Qs6153_OversizedFlatCommaValueThrowsBeforeDecoding()
+    {
+        var decodedValues = 0;
+        var options = new DecodeOptions
+        {
+            Comma = true,
+            ListLimit = 1,
+            ThrowOnLimitExceeded = true,
+            DecoderWithKind = (value, _, kind) =>
+            {
+                if (kind == DecodeKind.Value)
+                    decodedValues++;
+
+                return value;
+            }
+        };
+
+        Action act = () => Qs.Decode("a=1,2", options);
+
+        act.Should().Throw<InvalidOperationException>();
+        decodedValues.Should().Be(0);
+    }
+
+    [Fact]
+    public void Decode_Qs6153_BracketCommaGroupsCountAsOuterElements()
+    {
+        var options = new DecodeOptions
+        {
+            Comma = true,
+            ListLimit = 5,
+            ThrowOnLimitExceeded = true
+        };
+
+        Qs.Decode("a[]=1,2,3&a[]=4,5,6", options)
+            .Should()
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = new List<object?>
+                    {
+                        new List<object?> { "1", "2", "3" },
+                        new List<object?> { "4", "5", "6" }
+                    }
+                }
+            );
+
+        Action act = () => Qs.Decode(
+            "a[]=1,2,3",
+            new DecodeOptions
+            {
+                Comma = true,
+                ListLimit = 0,
+                ThrowOnLimitExceeded = true
+            }
+        );
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Decode_Qs6153_TopLevelParameterCountDoesNotDisableLists()
+    {
+        Qs.Decode("a[0]=x&b=y", new DecodeOptions { ListLimit = 1 })
+            .Should()
+            .BeEquivalentTo(
+                new Dictionary<string, object?>
+                {
+                    ["a"] = new List<object?> { "x" },
+                    ["b"] = "y"
+                }
+            );
+    }
+
+    [Fact]
+    public void Decode_Qs6153_PreservesMultiStepCycleIdentityForDictionaryInput()
+    {
+        var a = new Dictionary<string, object?>();
+        var b = new Dictionary<string, object?>();
+        var c = new Dictionary<string, object?>();
+        a["b"] = b;
+        b["c"] = c;
+        c["d"] = a;
+
+        var decoded = Qs.Decode(new Dictionary<string, object?> { ["foo"] = a });
+        decoded["foo"].Should().BeSameAs(a);
+        var decodedA = (IDictionary)decoded["foo"]!;
+        decodedA["b"].Should().BeSameAs(b);
+        var decodedB = (IDictionary)decodedA["b"]!;
+        decodedB["c"].Should().BeSameAs(c);
+        var decodedC = (IDictionary)decodedB["c"]!;
+
+        decodedC["d"].Should().BeSameAs(decodedA);
     }
 
     [Fact]

--- a/tests/QsNet.Tests/UtilsTests.cs
+++ b/tests/QsNet.Tests/UtilsTests.cs
@@ -2863,6 +2863,122 @@ public class UtilsTests
     }
 
     [Fact]
+    public void Merge_Qs6153_EnforcesListLimitAcrossListProducingPaths()
+    {
+        var options = new DecodeOptions { ListLimit = 1, ThrowOnLimitExceeded = true };
+
+        Action listScalar = () => Utils.Merge(new List<object?> { "a" }, "b", options);
+        Action scalarList = () => Utils.Merge("a", new List<object?> { "b", "c" }, options);
+        Action listList = () => Utils.Merge(
+            new List<object?> { "a" },
+            new List<object?> { "b" },
+            options
+        );
+        Action scalarMap = () => Utils.Merge(
+            "a",
+            new Dictionary<string, object?> { ["b"] = "c" },
+            options
+        );
+
+        listScalar.Should().Throw<InvalidOperationException>();
+        scalarList.Should().Throw<InvalidOperationException>();
+        listList.Should().Throw<InvalidOperationException>();
+        scalarMap.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Merge_Qs6153_ConvertsOverLimitListsToOverflowMaps()
+    {
+        var options = new DecodeOptions { ListLimit = 1 };
+        var cases = new (object? Target, object? Source)[]
+        {
+            (new List<object?> { "a" }, "b"),
+            ("a", new List<object?> { "b", "c" }),
+            (new List<object?> { "a" }, new List<object?> { "b" })
+        };
+
+        foreach (var (target, source) in cases)
+        {
+            var merged = Utils.Merge(target, source, options);
+
+            Utils.IsOverflow(merged).Should().BeTrue();
+            merged.Should().BeAssignableTo<IDictionary>();
+        }
+    }
+
+    [Fact]
+    public void Merge_Qs6153_EnforcesLimitAfterNestedListMerge()
+    {
+        var target = new List<object?>
+        {
+            new Dictionary<string, object?> { ["a"] = 1 }
+        };
+        var source = new List<object?>
+        {
+            new Dictionary<string, object?> { ["b"] = 2 },
+            new Dictionary<string, object?> { ["c"] = 3 }
+        };
+
+        var merged = Utils.Merge(target, source, new DecodeOptions { ListLimit = 1 });
+
+        Utils.IsOverflow(merged).Should().BeTrue();
+        merged.Should().BeEquivalentTo(
+            new Dictionary<string, object?>
+            {
+                ["0"] = new Dictionary<string, object?> { ["a"] = 1, ["b"] = 2 },
+                ["1"] = new Dictionary<string, object?> { ["c"] = 3 }
+            }
+        );
+    }
+
+    [Fact]
+    public void Merge_Qs6153_StrictOverflowDoesNotMutateInputList()
+    {
+        var target = new List<object?> { "a" };
+
+        Action act = () => Utils.Merge(
+            target,
+            new List<object?> { "b" },
+            new DecodeOptions { ListLimit = 1, ThrowOnLimitExceeded = true }
+        );
+
+        act.Should().Throw<InvalidOperationException>();
+        target.Should().Equal("a");
+    }
+
+    [Fact]
+    public void Merge_Qs6153_PreservesSetAndStrictMergeAsymmetry()
+    {
+        var options = new DecodeOptions { ListLimit = 1, ThrowOnLimitExceeded = true };
+        var set = Utils.Merge(new HashSet<object?> { "a" }, new HashSet<object?> { "b" }, options);
+
+        set.Should()
+            .BeOfType<HashSet<object?>>()
+            .Which.Should().BeEquivalentTo(new object?[] { "a", "b" });
+
+        Action scalarThenMap = () => Utils.Merge(
+            "a",
+            new Dictionary<string, object?> { ["b"] = "c" },
+            options
+        );
+        scalarThenMap.Should().Throw<InvalidOperationException>();
+
+        Utils.Merge(
+                new Dictionary<string, object?> { ["b"] = "c" },
+                "a",
+                options
+            )
+            .Should()
+            .BeEquivalentTo(
+                new List<object?>
+                {
+                    new Dictionary<string, object?> { ["b"] = "c" },
+                    "a"
+                }
+            );
+    }
+
+    [Fact]
     public void Merge_RemovesUndefinedEntriesWhenListsAreDisabled()
     {
         var undefined = Undefined.Create();
@@ -2880,6 +2996,16 @@ public class UtilsTests
         const string highSurrogate = "\uD83D"; // lone high surrogate, invalid pair
         var encoded = Utils.Encode(highSurrogate);
         encoded.Should().Be("%ED%A0%BD");
+    }
+
+    [Theory]
+    [InlineData(1023)]
+    [InlineData(2047)]
+    public void Encode_Qs6153_PreservesSurrogatePairsAcrossChunkBoundaries(int prefixLength)
+    {
+        var input = new string('a', prefixLength) + "😀";
+
+        Utils.Encode(input).Should().Be(new string('a', prefixLength) + "%F0%9F%98%80");
     }
 
     [Fact]
@@ -2910,9 +3036,8 @@ public class UtilsTests
         converted.Should().ContainKey("next");
         var next = converted["next"].Should().BeOfType<Dictionary<string, object?>>().Which;
         next.Should().ContainKey("back");
-        var back = next["back"].Should().BeOfType<Dictionary<string, object?>>().Which;
-        back.Should().ContainKey("next");
-        back["next"].Should().BeAssignableTo<IDictionary>();
+        next["back"].Should().BeSameAs(converted);
+        converted["next"].Should().BeSameAs(next);
     }
 
     [Fact]
@@ -3103,7 +3228,7 @@ public class UtilsTests
 
         var converted = Utils.ConvertNestedDictionary(parent);
 
-        converted["self"].Should().BeSameAs(parent);
+        converted["self"].Should().BeSameAs(converted);
         converted["string"].Should().BeSameAs(stringChild);
     }
 

--- a/tests/QsNet.Tests/UtilsTests.cs
+++ b/tests/QsNet.Tests/UtilsTests.cs
@@ -1479,7 +1479,7 @@ public class UtilsTests
     }
 
     [Fact]
-    public void ShouldAdvanceOverflowMaxIndexWhenUndefinedIterableSlotsAreMerged()
+    public void ShouldNotAdvanceOverflowMaxIndexWhenUndefinedIterableSlotsAreMerged()
     {
         var options = new DecodeOptions { ListLimit = 1 };
         var overflow = Utils.CombineWithLimit(new List<object?> { "a" }, "b", options);
@@ -1495,7 +1495,7 @@ public class UtilsTests
                 {
                     ["0"] = "a",
                     ["1"] = "b",
-                    ["4"] = "c"
+                    ["2"] = "c"
                 }
             );
     }
@@ -1685,10 +1685,9 @@ public class UtilsTests
         merged.Should().BeEquivalentTo(
             new Dictionary<object, object?>
             {
-                ["0"] = "a",
+                ["0"] = new List<object?> { "a", "c" },
                 ["1"] = "b",
-                ["2"] = "c",
-                ["4"] = "d"
+                ["2"] = "d"
             }
         );
         Utils.IsOverflow(merged).Should().BeTrue();
@@ -1697,11 +1696,10 @@ public class UtilsTests
         appended.Should().BeEquivalentTo(
             new Dictionary<object, object?>
             {
-                ["0"] = "a",
+                ["0"] = new List<object?> { "a", "c" },
                 ["1"] = "b",
-                ["2"] = "c",
-                ["4"] = "d",
-                ["5"] = "tail"
+                ["2"] = "d",
+                ["3"] = "tail"
             }
         );
     }
@@ -1722,8 +1720,7 @@ public class UtilsTests
             new Dictionary<object, object?>
             {
                 ["0"] = "a",
-                ["1"] = "b",
-                ["3"] = "c"
+                ["1"] = new List<object?> { "b", "c" }
             }
         );
         Utils.IsOverflow(merged).Should().BeTrue();
@@ -1733,9 +1730,8 @@ public class UtilsTests
             new Dictionary<object, object?>
             {
                 ["0"] = "a",
-                ["1"] = "b",
-                ["3"] = "c",
-                ["4"] = "tail"
+                ["1"] = new List<object?> { "b", "c" },
+                ["2"] = "tail"
             }
         );
     }

--- a/tests/QsNet.Tests/UtilsTests.cs
+++ b/tests/QsNet.Tests/UtilsTests.cs
@@ -1312,6 +1312,27 @@ public class UtilsTests
     }
 
     [Fact]
+    public void Combine_WithNegativeListLimitConvertsToMapOrThrows()
+    {
+        var combined = Utils.CombineWithLimit(
+            new List<object?>(),
+            "a",
+            new DecodeOptions { ListLimit = -1 }
+        );
+        combined.Should().BeEquivalentTo(new Dictionary<object, object?> { ["0"] = "a" });
+        Utils.IsOverflow(combined).Should().BeTrue();
+
+        Action act = () => Utils.CombineWithLimit(
+            new List<object?>(),
+            "a",
+            new DecodeOptions { ListLimit = -1, ThrowOnLimitExceeded = true }
+        );
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("List limit exceeded. Only -1 elements allowed in a list.");
+    }
+
+    [Fact]
     public void Combine_WithOverflowObject_AppendsAtNextIndex()
     {
         var overflow = Utils.CombineWithLimit(


### PR DESCRIPTION
This pull request focuses on bringing the query string decoding behavior in line with Node `qs` 6.15.3, especially regarding list-limit enforcement and edge-case handling. It also improves documentation to clarify the new behaviors and fixes, and updates internal logic to ensure all values are preserved in overflow cases. The most important changes are grouped below.

**Behavior Alignment and Bug Fixes:**

* Enforces cumulative list limits consistently across duplicate, comma, and mixed list merges, and ensures that when limits are exceeded, overflow values are preserved in numeric-keyed dictionaries rather than truncated. This includes pre-split rejection for oversized flat comma values and disables list parsing only when `ParseLists` is false, not based on parameter count. [[1]](diffhunk://#diff-e528441794ed3e03af9ae2e6bb9d646c38431c6505058afe1bc5bf7833b30906L44-L72) [[2]](diffhunk://#diff-e528441794ed3e03af9ae2e6bb9d646c38431c6505058afe1bc5bf7833b30906L83-R88) [[3]](diffhunk://#diff-e528441794ed3e03af9ae2e6bb9d646c38431c6505058afe1bc5bf7833b30906L92-R98) [[4]](diffhunk://#diff-e528441794ed3e03af9ae2e6bb9d646c38431c6505058afe1bc5bf7833b30906L445-R451) [[5]](diffhunk://#diff-e528441794ed3e03af9ae2e6bb9d646c38431c6505058afe1bc5bf7833b30906L468-L473) [[6]](diffhunk://#diff-e528441794ed3e03af9ae2e6bb9d646c38431c6505058afe1bc5bf7833b30906L557-R519) [[7]](diffhunk://#diff-e528441794ed3e03af9ae2e6bb9d646c38431c6505058afe1bc5bf7833b30906L570-R532) [[8]](diffhunk://#diff-c88931458fc5955efc2676474c4bfde9df645ccbfebbc13c97018bd9552646b2L148-R148) [[9]](diffhunk://#diff-c88931458fc5955efc2676474c4bfde9df645ccbfebbc13c97018bd9552646b2L189-R189) [[10]](diffhunk://#diff-c88931458fc5955efc2676474c4bfde9df645ccbfebbc13c97018bd9552646b2L203-R203) [[11]](diffhunk://#diff-c88931458fc5955efc2676474c4bfde9df645ccbfebbc13c97018bd9552646b2L218-R229) [[12]](diffhunk://#diff-c88931458fc5955efc2676474c4bfde9df645ccbfebbc13c97018bd9552646b2L288-R288) [[13]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6)

* Fixes lenient unbalanced-bracket handling and preserves multi-step cyclic dictionary identity during decoding, ensuring that edge cases are handled as in the latest upstream version. [[1]](diffhunk://#diff-e528441794ed3e03af9ae2e6bb9d646c38431c6505058afe1bc5bf7833b30906L496-L536) [[2]](diffhunk://#diff-e528441794ed3e03af9ae2e6bb9d646c38431c6505058afe1bc5bf7833b30906L728) [[3]](diffhunk://#diff-e528441794ed3e03af9ae2e6bb9d646c38431c6505058afe1bc5bf7833b30906L764) [[4]](diffhunk://#diff-e528441794ed3e03af9ae2e6bb9d646c38431c6505058afe1bc5bf7833b30906L801-R759) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6)

**Documentation Updates:**

* Updates `CHANGELOG.md`, `README.md`, and `docs/docs/decoding.md` to reflect the new list-limit enforcement, dictionary overflow preservation, and improved explanation of option behaviors. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L469-R471) [[3]](diffhunk://#diff-11e598b29761973679cfd9d320b364e5607ceb3867e6d9961ed38afc21dd1ba7L73-R73) [[4]](diffhunk://#diff-11e598b29761973679cfd9d320b364e5607ceb3867e6d9961ed38afc21dd1ba7L199-R201)

* Refines the `skills/qsnet/SKILL.md` documentation to clarify default behaviors, overflow handling, and the effect of options like `ThrowOnLimitExceeded` and `ParseLists`. [[1]](diffhunk://#diff-b3582f808ff353c5b0f84115937844cbdb791100c4d53bda09efd00bea956de9L387-R392) [[2]](diffhunk://#diff-b3582f808ff353c5b0f84115937844cbdb791100c4d53bda09efd00bea956de9L506-R511)

**Internal Refactoring:**

* Refactors internal code to use a consistent exception for list-limit overflow, and improves handling of source lists and dictionaries during merges to preserve all values and ensure correct assignment. [[1]](diffhunk://#diff-0b44b5ea19fabbc136cb8c8f41db51ab833ecd5de1e91599c8716cd993395dd7L63-R63) [[2]](diffhunk://#diff-c88931458fc5955efc2676474c4bfde9df645ccbfebbc13c97018bd9552646b2L218-R229)

These changes ensure that the decoder matches the latest `qs` behavior, handles all edge cases robustly, and that documentation accurately describes the new and fixed behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding and merging of lists, overflow values, and cyclic/nested data so values are preserved more consistently at limit boundaries.
  * Fixed bracket, comma, and trailing-text parsing edge cases to better match expected query behavior.
  * Updated limit handling so list parsing and overflow behavior are more predictable, including when limits are exceeded.

* **Documentation**
  * Clarified list overflow, limit, and parsing rules in the changelog, README, and decoding guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->